### PR TITLE
Add code style fixer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+bin
 config/*
 !config/.keep
 var
 vendor
 composer.lock
+.php-cs-fixer.cache

--- a/composer.json
+++ b/composer.json
@@ -14,5 +14,11 @@
     "psr-4": {
       "racacax\\XmlTv\\": "src/"
     }
+  },
+  "config": {
+    "bin-dir": "bin"
+  },
+  "require-dev": {
+    "friendsofphp/php-cs-fixer": "^3.3"
   }
 }

--- a/makefile
+++ b/makefile
@@ -1,0 +1,4 @@
+
+PHONY: quality
+quality:
+	 bin/php-cs-fixer fix src

--- a/resources/channel_config/channels_telerama.json
+++ b/resources/channel_config/channels_telerama.json
@@ -137,7 +137,6 @@
  "France3RhoneAlpes.fr": 1944,
  "France4.fr": 78,
  "France5.fr": 47,
- "FranceO.fr": 160,
  "FranceInfo.fr": 2111,
  "GameOne.fr": 87,
  "Ginx.fr": 563,

--- a/resources/channel_config/channels_telez.json
+++ b/resources/channel_config/channels_telez.json
@@ -17,7 +17,6 @@
 "CNews.fr": 73,
 "CStar.fr": 70,
 "Gulli.fr": 65,
-"FranceO.fr": 66,
 "TF1SeriesFilms.fr": 64,
 "LEquipe21.fr": 63,
 "6ter.fr": 76,

--- a/resources/config/default_channels.json
+++ b/resources/config/default_channels.json
@@ -115,7 +115,6 @@
   "France3RhoneAlpes.fr": {},
   "France4.fr": {},
   "France5.fr": {},
-  "FranceO.fr": {},
   "FranceInfo.fr": {},
   "GameOne.fr": {},
   "Ginx.fr": {},

--- a/src/Component/CacheFile.php
+++ b/src/Component/CacheFile.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
@@ -14,9 +15,9 @@ class CacheFile
 
     public function __construct(string $basePath)
     {
-        @mkdir($basePath,0777, true);
+        @mkdir($basePath, 0777, true);
 
-        $this->basePath = rtrim($basePath,DIRECTORY_SEPARATOR);
+        $this->basePath = rtrim($basePath, DIRECTORY_SEPARATOR);
     }
 
     public function store(string $key, string $content)
@@ -38,7 +39,7 @@ class CacheFile
             return true;
         }
         $fileName = $this->basePath . DIRECTORY_SEPARATOR . $key;
-        if (file_exists($fileName)){
+        if (file_exists($fileName)) {
             $this->listFile[$key] = [
                 'file'=> $fileName,
                 'key' => $key
@@ -62,8 +63,8 @@ class CacheFile
     {
         $files = glob($this->basePath.DIRECTORY_SEPARATOR.'*');
 
-        foreach($files as $file){
-            if (time()-filemtime($file) >= 86400 * $maxCacheDay){
+        foreach ($files as $file) {
+            if (time()-filemtime($file) >= 86400 * $maxCacheDay) {
                 unlink($file);
             }
         }

--- a/src/Component/ChannelFactory.php
+++ b/src/Component/ChannelFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
@@ -8,7 +9,9 @@ use racacax\XmlTv\ValueObject\Channel;
 
 class ChannelFactory
 {
-    private function __construct(){}
+    private function __construct()
+    {
+    }
 
     public static function createChannel(string $channelKey): Channel
     {

--- a/src/Component/Logger.php
+++ b/src/Component/Logger.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
@@ -21,7 +22,7 @@ class Logger
     }
     public static function setLogFolder(string $path): void
     {
-        @mkdir($path,0777, true);
+        @mkdir($path, 0777, true);
 
         self::$debugFolder = rtrim($path, DIRECTORY_SEPARATOR);
     }
@@ -62,7 +63,7 @@ class Logger
     public static function clearLog(): void
     {
         array_map(
-            function($file){
+            function ($file) {
                 unlink($file);
             },
             glob(self::$debugFolder.DIRECTORY_SEPARATOR.'*')

--- a/src/Component/Provider/AbstractProvider.php
+++ b/src/Component/Provider/AbstractProvider.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
@@ -6,8 +7,8 @@ namespace racacax\XmlTv\Component\Provider;
 use racacax\XmlTv\Component\ChannelFactory;
 use racacax\XmlTv\ValueObject\Channel;
 
-abstract class AbstractProvider {
-
+abstract class AbstractProvider
+{
     /**
      * @var Channel|null
      */
@@ -20,7 +21,7 @@ abstract class AbstractProvider {
 
     protected static $priority;
 
-    public function __construct($jsonPath, $priority)
+    public function __construct(string $jsonPath, float $priority)
     {
         if (empty($this->channelsList) && file_exists($jsonPath)) {
             $this->channelsList = json_decode(file_get_contents($jsonPath), true);
@@ -63,7 +64,7 @@ abstract class AbstractProvider {
         curl_setopt($ch1, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch1, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($ch1, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0');
-        $res1 = html_entity_decode(curl_exec($ch1),ENT_QUOTES);
+        $res1 = html_entity_decode(curl_exec($ch1), ENT_QUOTES);
         curl_close($ch1);
         return $res1;
     }

--- a/src/Component/Provider/Afrique.php
+++ b/src/Component/Provider/Afrique.php
@@ -1,15 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 class Afrique extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath('channels_afrique.json'), $priority ?? 0.2);
@@ -18,8 +17,9 @@ class Afrique extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $day = (strtotime($date) - strtotime(date('Y-m-d')))/86400;
         $ch3 = curl_init();
         curl_setopt($ch3, CURLOPT_URL, 'https://service.canal-overseas.com/ott-frontend/vector/83001/channel/' . $this->channelsList[$channel] . '/events?filter.day=' . $day);
@@ -30,9 +30,10 @@ class Afrique extends AbstractProvider implements ProviderInterface
         curl_setopt($ch3, CURLOPT_FOLLOWLOCATION, 1);
         $res3 = curl_exec($ch3);
         curl_close($ch3);
-        $res2 = json_decode($res3,true);
-        if(!isset($res2['timeSlices']))
+        $res2 = json_decode($res3, true);
+        if (!isset($res2['timeSlices'])) {
             return false;
+        }
         $res3 = json_decode($res3, true);
         $json = $res3["timeSlices"];
         $count = 0;

--- a/src/Component/Provider/Bouygues.php
+++ b/src/Component/Provider/Bouygues.php
@@ -4,23 +4,23 @@ declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
 
-
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 // Original script by lazel on https://github.com/lazel/XML-TV-Fr/blob/master/classes/Bouygues.php
-class Bouygues extends AbstractProvider implements ProviderInterface {
-
-
+class Bouygues extends AbstractProvider implements ProviderInterface
+{
     public function __construct(?float $priority = null, array $extraParam = [])
     {
-        parent::__construct(ResourcePath::getInstance()->getChannelPath('channels_bouygues.json'),$priority ?? 0.9);
+        parent::__construct(ResourcePath::getInstance()->getChannelPath('channels_bouygues.json'), $priority ?? 0.9);
     }
 
-    public function constructEPG(string $channel, string $date) {
+    public function constructEPG(string $channel, string $date)
+    {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
 
         $channelId = $this->getChannelsList()[$channel];
 
@@ -38,28 +38,35 @@ class Bouygues extends AbstractProvider implements ProviderInterface {
 
         $json = json_decode($get, true);
 
-        if(!isset($json['channel'][0]['event']) || empty($json['channel'][0]['event'])) return false;
+        if (!isset($json['channel'][0]['event']) || empty($json['channel'][0]['event'])) {
+            return false;
+        }
 
 
-        foreach($json['channel'][0]['event'] as $program) {
+        foreach ($json['channel'][0]['event'] as $program) {
             $genre = @$program['programInfo']['genre'][0];
             $subGenre = @$program['programInfo']['subGenre'][0];
 
-            if(isset($program['parentalGuidance'])) {
+            if (isset($program['parentalGuidance'])) {
                 $csa = explode('.', $program['parentalGuidance']);
 
-                switch((int)end($csa)) {
+                switch ((int)end($csa)) {
                     case 2: $csa = '-10'; break;
                     case 3: $csa = '-12'; break;
                     case 4: $csa = '-16'; break;
                     case 5: $csa = '-18'; break;
                     default: $csa = 'Tout public';  break;
                 }
-            } else $csa = 'Tout public';
+            } else {
+                $csa = 'Tout public';
+            }
 
-            if(!is_null($genre) && !is_null($subGenre) && $genre == $subGenre) {
-                if(isset($program['programInfo']['genre'][1])) $genre = $program['programInfo']['genre'][1];
-                else $subGenre = null;
+            if (!is_null($genre) && !is_null($subGenre) && $genre == $subGenre) {
+                if (isset($program['programInfo']['genre'][1])) {
+                    $genre = $program['programInfo']['genre'][1];
+                } else {
+                    $subGenre = null;
+                }
             }
             $programObj = $this->channelObj->addProgram(strtotime($program['startTime']), strtotime($program['endTime']));
             $programObj->addTitle($program['programInfo']['longTitle']);

--- a/src/Component/Provider/ICIRadioCanadaTele.php
+++ b/src/Component/Provider/ICIRadioCanadaTele.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
@@ -13,18 +13,17 @@ use racacax\XmlTv\Component\ResourcePath;
  */
 class ICIRadioCanadaTele extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
-
-        parent::__construct(ResourcePath::getInstance()->getChannelPath( 'channels_iciradiocanada.json'), 0.6);
+        parent::__construct(ResourcePath::getInstance()->getChannelPath('channels_iciradiocanada.json'), 0.6);
     }
 
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if (!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $channel_id = $this->channelsList[$channel];
 
 
@@ -37,20 +36,17 @@ class ICIRadioCanadaTele extends AbstractProvider implements ProviderInterface
         curl_setopt($ch1, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0");
         $res1 = curl_exec($ch1);
         curl_close($ch1);
-        $json = @json_decode($res1,true);
-        if(!isset($json["data"]["broadcasts"]))
+        $json = @json_decode($res1, true);
+        if (!isset($json["data"]["broadcasts"])) {
             return false;
-        foreach($json["data"]["broadcasts"] as $broadcast)
-        {
+        }
+        foreach ($json["data"]["broadcasts"] as $broadcast) {
             $program = $this->channelObj->addProgram(strtotime($broadcast["startsAt"]), strtotime($broadcast["endsAt"]));
             $program->addCategory($broadcast["subtheme"]);
-            $program->setIcon(str_replace('{0}', "635", str_replace('{1}', '16x9',@$broadcast["pircture"]["url"])));
+            $program->setIcon(str_replace('{0}', "635", str_replace('{1}', '16x9', @$broadcast["pircture"]["url"])));
             $program->addTitle($broadcast["title"]);
             $program->addSubtitle($broadcast["subtitle"]);
-
         }
         return $this->channelObj;
     }
-
-
 }

--- a/src/Component/Provider/La1ere.php
+++ b/src/Component/Provider/La1ere.php
@@ -1,15 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 class La1ere extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_1ere.json"), $priority ?? 0.3);
@@ -18,11 +17,10 @@ class La1ere extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if($date != date('Y-m-d')) {
+        if ($date != date('Y-m-d')) {
             return false;
         }
-        if(!$this->channelExists($channel))
-        {
+        if (!$this->channelExists($channel)) {
             return false;
         }
         date_default_timezone_set($this->channelsList[$channel]["timezone"]);
@@ -34,30 +32,30 @@ class La1ere extends AbstractProvider implements ProviderInterface
         curl_setopt($ch1, CURLOPT_SSL_VERIFYHOST, 0);
         curl_setopt($ch1, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($ch1, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0');
-        $res1 = html_entity_decode(curl_exec($ch1),ENT_QUOTES);
+        $res1 = html_entity_decode(curl_exec($ch1), ENT_QUOTES);
         curl_close($ch1);
         $days = explode('<div class="guide">', $res1);
         $infos = [];
         unset($days[0]);
         $days = array_values($days);
-        foreach($days as $key => $day) {
+        foreach ($days as $key => $day) {
             $programs = explode('</li>', $day);
-            foreach($programs as $program) {
-                preg_match('/\<span class=\"program-hour\".*?\>(.*?)\<\/span\>/',$program, $hour);
-                preg_match('/\<span class=\"program-name\".*?\>(.*?)\<\/span\>/',$program, $name);
-                preg_match('/\<div class=\"subtitle\".*?\>(.*?)\<\/div\>/',$program, $subtitle);
-                if(isset($name[1])) {
+            foreach ($programs as $program) {
+                preg_match('/\<span class=\"program-hour\".*?\>(.*?)\<\/span\>/', $program, $hour);
+                preg_match('/\<span class=\"program-name\".*?\>(.*?)\<\/span\>/', $program, $name);
+                preg_match('/\<div class=\"subtitle\".*?\>(.*?)\<\/div\>/', $program, $subtitle);
+                if (isset($name[1])) {
                     $infos[] = array(
-                        "hour" => date('YmdHis O', strtotime(date('Ymd', strtotime("now") + 86400 * $key) . ' ' . str_replace('H',':',$hour[1]))),
+                        "hour" => date('YmdHis O', strtotime(date('Ymd', strtotime("now") + 86400 * $key) . ' ' . str_replace('H', ':', $hour[1]))),
                         "title" => $name[1],
                         "subtitle" => @$subtitle[1]
                     );
                 }
             }
         }
-        for($i=0; $i<count($infos)-1; $i++) {
+        for ($i=0; $i<count($infos)-1; $i++) {
             $program = $this->channelObj->addProgram(strtotime($infos[$i]["hour"]), strtotime($infos[$i+1]["hour"]));
-            if(strlen($infos[$i+1]["subtitle"])>0) {
+            if (strlen($infos[$i+1]["subtitle"])>0) {
                 $program->addSubtitle($infos[$i+1]["subtitle"]);
             }
             $program->addTitle($infos[$i]["title"]);

--- a/src/Component/Provider/MyCanal.php
+++ b/src/Component/Provider/MyCanal.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
@@ -8,7 +9,8 @@ use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 // Edited by lazel from https://github.com/lazel/XML-TV-Fr/blob/master/classes/MyCanal.php
-class MyCanal extends AbstractProvider implements ProviderInterface {
+class MyCanal extends AbstractProvider implements ProviderInterface
+{
     private static $apiKey = '4ca2e967e4ca296ab18dab5432f906ac';
 
     public function __construct(?float $priority = null, array $extraParam = [])
@@ -16,10 +18,12 @@ class MyCanal extends AbstractProvider implements ProviderInterface {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_mycanal.json"), $priority ?? 0.7);
     }
 
-    public function constructEPG(string $channel, string $date) {
+    public function constructEPG(string $channel, string $date)
+    {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $channelId = $this->getChannelsList()[$channel];
         $day = (strtotime($date) - strtotime(date('Y-m-d'))) / 86400;
 
@@ -35,7 +39,7 @@ class MyCanal extends AbstractProvider implements ProviderInterface {
 
         do {
             curl_multi_exec($curl_multi, $running);
-        } while($running > 0);
+        } while ($running > 0);
 
         $get = curl_multi_getcontent($curl);
         $get2 = curl_multi_getcontent($curl1);
@@ -49,19 +53,23 @@ class MyCanal extends AbstractProvider implements ProviderInterface {
         $json = json_decode($get, true);
         $json2 = json_decode($get2, true);
 
-        if(!isset($json['timeSlices']) || empty($json['timeSlices'])) return false;
+        if (!isset($json['timeSlices']) || empty($json['timeSlices'])) {
+            return false;
+        }
 
         $all = [];
-        foreach($json['timeSlices'] as $section) {
+        foreach ($json['timeSlices'] as $section) {
             $all = array_merge($all, $section['contents']);
         }
 
-        if(@$nd = $json2['timeSlices'][0]['contents'][0]) $all[] = $nd;
+        if (@$nd = $json2['timeSlices'][0]['contents'][0]) {
+            $all[] = $nd;
+        }
 
         $programs = [];
         $lastTime = 0;
         $count = count($all);
-        foreach($all as $index => $program) {
+        foreach ($all as $index => $program) {
             Logger::updateLine(" ".round($index*100/$count, 2)." %");
             $curld = curl_init($program['onClick']['URLPage']);
             curl_setopt($curld, CURLOPT_RETURNTRANSFER, 1);
@@ -75,7 +83,7 @@ class MyCanal extends AbstractProvider implements ProviderInterface {
 
             $parentalRating = $detail['episodes']['contents'][0]['parentalRatings'][0]['value'] ?? @$detail['detail']['informations']['parentalRatings'][0]['value'];
 
-            switch($parentalRating) {
+            switch ($parentalRating) {
                 case '2': $csa = '-10'; break;
                 case '3': $csa = '-12'; break;
                 case '4': $csa = '-16'; break;
@@ -101,7 +109,7 @@ class MyCanal extends AbstractProvider implements ProviderInterface {
                 'csa'           => $csa
             ];
 
-            if($lastTime > 0) {
+            if ($lastTime > 0) {
                 $lastProgram = $programs[$lastTime];
                 $programObj = $this->channelObj->addProgram($lastProgram['startTime'], $startTime);
                 $programObj->addTitle($lastProgram['title']);

--- a/src/Component/Provider/Orange.php
+++ b/src/Component/Provider/Orange.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
@@ -21,8 +21,9 @@ class Orange extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if (!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $channel_id = $this->channelsList[$channel];
 
 
@@ -35,16 +36,15 @@ class Orange extends AbstractProvider implements ProviderInterface
         curl_setopt($ch1, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0");
         $res1 = curl_exec($ch1);
         curl_close($ch1);
-        $json = json_decode($res1,true);
-        if(preg_match('(Invalid request)',$res1) || preg_match('(504 Gateway Time-out)',$res1) || !isset($json))
-        {
+        $json = json_decode($res1, true);
+        if (preg_match('(Invalid request)', $res1) || preg_match('(504 Gateway Time-out)', $res1) || !isset($json)) {
             return false;
         }
-        if(isset($json['code']))
+        if (isset($json['code'])) {
             return false;
-        foreach($json as $val)
-        {
-            switch(@$val["csa"]) {
+        }
+        foreach ($json as $val) {
+            switch (@$val["csa"]) {
                 case '2': $csa = '-10'; break;
                 case '3': $csa = '-12'; break;
                 case '4': $csa = '-16'; break;
@@ -55,22 +55,22 @@ class Orange extends AbstractProvider implements ProviderInterface
             $program->addDesc($val["synopsis"]);
             $program->addCategory($val["genre"]);
             $program->addCategory($val["genreDetailed"]);
-            $program->setIcon((!empty($val["covers"])?''.end($val["covers"])["url"]:''));
+            $program->setIcon((!empty($val["covers"]) ? ''.end($val["covers"])["url"] : ''));
             $program->setRating($csa);
-            if(!isset($val["season"]))
-            {
+            if (!isset($val["season"])) {
                 $program->addTitle($val["title"]);
             } else {
-                if($val["season"]["number"] =="") { $val["season"]["number"] ='1';} if($val["episodeNumber"] =="") { $val["episodeNumber"] ='1';}
+                if ($val["season"]["number"] =="") {
+                    $val["season"]["number"] ='1';
+                }
+                if ($val["episodeNumber"] =="") {
+                    $val["episodeNumber"] ='1';
+                }
                 $program->addTitle($val["season"]["serie"]["title"]);
                 $program->setEpisodeNum($val["season"]["number"], $val["episodeNumber"]);
                 $program->addSubtitle($val["title"]);
             }
-
-
         }
         return $this->channelObj;
     }
-
-
 }

--- a/src/Component/Provider/Proximus.php
+++ b/src/Component/Provider/Proximus.php
@@ -1,24 +1,25 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
 
-
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
-class Proximus extends AbstractProvider implements ProviderInterface {
-
-
+class Proximus extends AbstractProvider implements ProviderInterface
+{
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath('channels_proximus.json'), $priority ?? 0.59);
     }
 
-    public function constructEPG(string $channel, string $date) {
+    public function constructEPG(string $channel, string $date)
+    {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
 
         $channelId = $this->getChannelsList()[$channel];
         $timestamp = strtotime($date);
@@ -30,19 +31,23 @@ class Proximus extends AbstractProvider implements ProviderInterface {
 
         $programs = @$json['data']['schedulesByInterval'];
 
-        if(!isset($programs) || empty($programs)) return false;
+        if (!isset($programs) || empty($programs)) {
+            return false;
+        }
 
 
-        foreach($programs as $program) {
-            if(isset($program['parentalRating'])) {
-                switch($program['parentalRating']) {
+        foreach ($programs as $program) {
+            if (isset($program['parentalRating'])) {
+                switch ($program['parentalRating']) {
                     case '10': $csa = '-10'; break;
                     case '12': $csa = '-12'; break;
                     case '16': $csa = '-16'; break;
                     case '18': $csa = '-18'; break;
                     default: $csa = 'Tout public';  break;
                 }
-            } else $csa = 'Tout public';
+            } else {
+                $csa = 'Tout public';
+            }
             $programObj = $this->channelObj->addProgram($program['startTime'], $program['endTime']);
             $programObj->addTitle($program['title'] ?? '');
             $programObj->addDesc(@$program['description']);

--- a/src/Component/Provider/SFR.php
+++ b/src/Component/Provider/SFR.php
@@ -1,15 +1,15 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 // Original script by lazel from https://github.com/lazel/XML-TV-Fr/blob/master/classes/SFR.php
-class SFR extends AbstractProvider implements ProviderInterface {
-
+class SFR extends AbstractProvider implements ProviderInterface
+{
     private $jsonPerDay;
 
     public function __construct(?float $priority = null, array $extraParam = [])
@@ -18,14 +18,16 @@ class SFR extends AbstractProvider implements ProviderInterface {
         $this->jsonPerDay = [];
     }
 
-    public function constructEPG(string $channel, string $date) {
+    public function constructEPG(string $channel, string $date)
+    {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
 
         $channelId = $this->getChannelsList()[$channel];
 
-        if(!isset($this->jsonPerDay[$date])) {
+        if (!isset($this->jsonPerDay[$date])) {
             $curl = curl_init('https://static-cdn.tv.sfr.net/data/epg/gen8/guide_web_' . str_replace('-', '', $date) . '.json');
             curl_setopt($curl, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:49.0) Gecko/20100101 Firefox/49.0');
             curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
@@ -34,7 +36,7 @@ class SFR extends AbstractProvider implements ProviderInterface {
             curl_setopt($curl, CURLOPT_SSL_VERIFYHOST, false);
             $get = curl_exec($curl);
             curl_close($curl);
-            if($get===false) {
+            if ($get===false) {
                 return false;
             }
             $json = json_decode($get, true);
@@ -45,19 +47,23 @@ class SFR extends AbstractProvider implements ProviderInterface {
 
         $programs = @$json['epg'];
 
-        if(!isset($programs[$channelId]) || empty($programs[$channelId])) return false;
+        if (!isset($programs[$channelId]) || empty($programs[$channelId])) {
+            return false;
+        }
 
 
-        foreach($programs[$channelId] as $program) {
-            if(isset($program['moralityLevel'])) {
-                switch($program['moralityLevel']) {
+        foreach ($programs[$channelId] as $program) {
+            if (isset($program['moralityLevel'])) {
+                switch ($program['moralityLevel']) {
                     case '2': $csa = '-10'; break;
                     case '3': $csa = '-12'; break;
                     case '4': $csa = '-16'; break;
                     case '5': $csa = '-18'; break;
                     default: $csa = 'Tout public';  break;
                 }
-            } else $csa = 'Tout public';
+            } else {
+                $csa = 'Tout public';
+            }
             $programObj = $this->channelObj->addProgram($program['startDate'] / 1000, $program['endDate'] / 1000);
             $programObj->addTitle($program['title'] ?? '');
             $programObj->addSubtitle(@$program['subTitle']);

--- a/src/Component/Provider/TV5.php
+++ b/src/Component/Provider/TV5.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
@@ -13,7 +13,6 @@ use racacax\XmlTv\Component\ResourcePath;
  */
 class TV5 extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_tv5.json"), $priority ?? 0.6);
@@ -23,8 +22,9 @@ class TV5 extends AbstractProvider implements ProviderInterface
     {
         parent::constructEPG($channel, $date);
 
-        if (!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $channel_id = $this->channelsList[$channel];
 
 
@@ -39,28 +39,27 @@ class TV5 extends AbstractProvider implements ProviderInterface
         curl_setopt($ch1, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0");
         $res1 = curl_exec($ch1);
         curl_close($ch1);
-        $json = json_decode($res1,true);
-        if(!@isset($json['data'][0]))
-        {
+        $json = json_decode($res1, true);
+        if (!@isset($json['data'][0])) {
             return false;
         }
-        foreach($json["data"] as $val)
-        {
+        foreach ($json["data"] as $val) {
             $program = $this->channelObj->addProgram(strtotime($val['utcstart']."+00:00"), strtotime($val['utcend']."+00:00"));
             $program->addTitle($val["title"]);
             $program->addDesc((!empty($val["description"])) ? $val["description"] : 'Pas de description');
             $program->addCategory($val["category"]);
-            $program->setIcon(!empty($val["image"])?''.$val["image"]:'');
-            if(isset($val["season"])) {
-                if($val["season"] =="") { $val["season"] ='1';} if($val["episode"] =="") { $val["episode"] ='1';}
+            $program->setIcon(!empty($val["image"]) ? ''.$val["image"] : '');
+            if (isset($val["season"])) {
+                if ($val["season"] =="") {
+                    $val["season"] ='1';
+                }
+                if ($val["episode"] =="") {
+                    $val["episode"] ='1';
+                }
                 $program->addSubtitle($val["episode_name"]);
                 $program->setEpisodeNum($val["season"], $val["episode"]);
             }
-
-
         }
         return $this->channelObj;
     }
-
-
 }

--- a/src/Component/Provider/TVHebdo.php
+++ b/src/Component/Provider/TVHebdo.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\Logger;
 use racacax\XmlTv\Component\ProviderInterface;
@@ -10,18 +10,19 @@ use racacax\XmlTv\Component\ResourcePath;
 
 class TVHebdo extends AbstractProvider implements ProviderInterface
 {
-
     private $proxy;
 
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_tvhebdo.json"), $priority ?? 0.2);
         $this->proxy = "http://www.ekamali.com/index.php";
-        if(isset($extraParam['tvhebdo_proxy']))
+        if (isset($extraParam['tvhebdo_proxy'])) {
             $this->proxy = $extraParam['tvhebdo_proxy'];
+        }
     }
 
-    protected function getContentFromURL($url): string {
+    protected function getContentFromURL($url): string
+    {
         $ch1 = curl_init();
         curl_setopt($ch1, CURLOPT_URL, $url);
         curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
@@ -30,7 +31,7 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
         curl_setopt($ch1, CURLOPT_SSL_VERIFYPEER, 0);
         curl_setopt($ch1, CURLOPT_REFERER, $this->proxy);
         curl_setopt($ch1, CURLOPT_USERAGENT, 'Mozilla/5.0 (Windows NT 10.0; WOW64; rv:52.0) Gecko/20100101 Firefox/52.0');
-        $res1 = html_entity_decode(curl_exec($ch1),ENT_QUOTES);
+        $res1 = html_entity_decode(curl_exec($ch1), ENT_QUOTES);
         curl_close($ch1);
         return $res1;
     }
@@ -39,56 +40,55 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
     {
         parent::constructEPG($channel, $date);
         date_default_timezone_set('America/Montreal');
-        if(!$this->channelExists($channel))
-        {
+        if (!$this->channelExists($channel)) {
             return false;
         }
         $res1 = $this->getContentFromURL($this->proxy.'?q='.base64_encode('http://www.tvhebdo.com/horaire-tele/'.$this->channelsList[$channel].'/date/'.$date).'&hl=3ed');
-        @$res1 = explode('Mes<br>alertes courriel',$res1)[1];
-        preg_match_all('/class="heure"\>(.*?)\<\/td\>/',$res1,$time);
-        preg_match_all('/class="titre"\>.*?href="(.*?)"\>(.*?)\<\/a\>/',$res1,$titre);
+        @$res1 = explode('Mes<br>alertes courriel', $res1)[1];
+        preg_match_all('/class="heure"\>(.*?)\<\/td\>/', $res1, $time);
+        preg_match_all('/class="titre"\>.*?href="(.*?)"\>(.*?)\<\/a\>/', $res1, $titre);
         $t8 = json_encode($time);
         $t9 = json_encode($titre);
         $t8 = $t8.'|||||||||||||||||||||||'.$t9;
-        if(strlen($t8)<=100){
-            return false; }
+        if (strlen($t8)<=100) {
+            return false;
+        }
 
         $count = count($titre[2]);
-        for($j=0;$j<$count;$j++)
-        {
+        for ($j=0;$j<$count;$j++) {
             Logger::updateLine(" ".round($j*100/$count, 2)." %");
             $dateStart = strtotime($date.' '.$time[1][$j]);
             $titreProgram = $titre[2][$j];
             $url = $titre[1][$j];
             $content = $this->getContentFromURL($url);
-            $infos = str_replace("\n", " ",explode('</h4>',explode('<h4>', $content)[1])[0]);
+            $infos = str_replace("\n", " ", explode('</h4>', explode('<h4>', $content)[1])[0]);
             $infos = explode(' - ', $infos);
             $genre = @trim($infos[0] ?? '');
             $duration = @intval(explode(' ', @trim($infos[1] ?? ''))[0]);
             $lang = @trim(strtolower($infos[2]) ?? '');
             $potentialYear = @strval(intval(@trim($infos[3] ?? '')));
-            if(@trim($infos[3] ?? '') == $potentialYear) {
+            if (@trim($infos[3] ?? '') == $potentialYear) {
                 $year = $potentialYear;
             } else {
                 $rating = @trim($infos[3] ?? '');
             }
-            if(isset($infos[4])) {
+            if (isset($infos[4])) {
                 $potentialYear = @intval(@trim($infos[4] ?? ''));
-                if(isset($potentialYear) && $potentialYear > 0) {
+                if (isset($potentialYear) && $potentialYear > 0) {
                     $year = $potentialYear;
                 }
             }
-            $desc =@explode('</p>',explode('<p id="dd_desc">', $content)[1])[0];
-            if(isset($year)) {
+            $desc =@explode('</p>', explode('<p id="dd_desc">', $content)[1])[0];
+            if (isset($year)) {
                 $desc.= "\n\nAnnée : ".$year;
             }
-            $intervenants = @explode('</p>',explode('<p id="dd_inter">', $content)[1])[0];
+            $intervenants = @explode('</p>', explode('<p id="dd_inter">', $content)[1])[0];
             $program = $this->channelObj->addProgram($dateStart, $dateStart+$duration*60);
             $program->addTitle($titreProgram, $lang);
-            $desc = str_replace('<br />', "\n",$desc.$intervenants);
+            $desc = str_replace('<br />', "\n", $desc.$intervenants);
             $tmp_desc = '';
             $splited_desc = explode("\n", $desc);
-            foreach($splited_desc as $line) {
+            foreach ($splited_desc as $line) {
                 $tmp_desc.=@trim($line)."\n";
             }
             $desc = $tmp_desc;
@@ -98,25 +98,26 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
             $intervenants_split = explode('<br />', $intervenants);
             foreach ($intervenants_split as $line) {
                 $line = @trim($line);
-                if($line == "Réalisation :") {
+                if ($line == "Réalisation :") {
                     $current_role = "director";
-                } elseif(strpos($line, ':') !== false) {
+                } elseif (strpos($line, ':') !== false) {
                     $current_role = "guest";
                 } else {
                     $program->addCredit($line, $current_role);
                 }
             }
-            $img_zone = explode('<div id="dd_votes_container">',explode('<div id="dd_votes">', $content)[1])[0];
+            $img_zone = explode('<div id="dd_votes_container">', explode('<div id="dd_votes">', $content)[1])[0];
             preg_match('/src="(.*?)"/', $img_zone, $img_url);
             $program->setIcon(@$img_url[1]);
-            if(isset($rating) && strlen($rating) > 0 && strlen($rating) < 4) {
-                if(in_array($rating, ["PG", "14A", "18A", "R", "A"]) || ($rating == "G" && $lang == "en")) {
+            if (isset($rating) && strlen($rating) > 0 && strlen($rating) < 4) {
+                if (in_array($rating, ["PG", "14A", "18A", "R", "A"]) || ($rating == "G" && $lang == "en")) {
                     $rating_system = "CHVRS";
                 } elseif (in_array($rating, ["G", "13", "16", "18"])) {
                     $rating_system = "RCQ";
                 }
-                if(isset($rating_system))
+                if (isset($rating_system)) {
                     $program->setRating($rating, $rating_system);
+                }
             }
         }
         return $this->channelObj;

--- a/src/Component/Provider/Tebeosud.php
+++ b/src/Component/Provider/Tebeosud.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\Logger;
 use racacax\XmlTv\Component\ProviderInterface;
@@ -10,7 +10,6 @@ use racacax\XmlTv\Component\ResourcePath;
 
 class Tebeosud extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_tebeosud.json"), $priority ?? 0.2);
@@ -19,10 +18,12 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if (!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
-        if($date != date('Y-m-d'))
+        }
+        if ($date != date('Y-m-d')) {
             return false;
+        }
         $channel_id = $this->channelsList[$channel];
 
 
@@ -35,28 +36,30 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
         curl_setopt($ch1, CURLOPT_USERAGENT, "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:49.0) Gecko/20100101 Firefox/49.0");
         $res1 = curl_exec($ch1);
         curl_close($ch1);
-        if(count(explode('<span class="rouge">Programme</span>', $res1)) < 2)
+        if (count(explode('<span class="rouge">Programme</span>', $res1)) < 2) {
             return false;
+        }
         $separateDays = explode('<h3 class="grid_16 titre">', $res1);
         $day = explode(' ', explode('<h2>', $res1)[1])[1];
-        if($day == date('d')) {
+        if ($day == date('d')) {
             $startDate = date('Y-m-d');
-        } elseif($day == date('d', strtotime("-1 days"))) {
+        } elseif ($day == date('d', strtotime("-1 days"))) {
             $startDate = date('Y-m-d', strtotime('-1 days'));
         } else {
             return false;
         }
         $programs = [];
         $count = count($separateDays);
-        for($i=0; $i<$count; $i++) {
+        for ($i=0; $i<$count; $i++) {
             preg_match_all('/\<td class="date"\>\<a href="(.*?)"\>(.*?)\<\/a\>\<\/td\>/', $separateDays[$i], $infos);
             preg_match_all('/\<td class="nom"\>\<a href="(.*?)"\>(.*?)\<\/a\>\<\/td\>/', $separateDays[$i], $infos2);
             $count2 = count($infos[1]);
-            for($j=0; $j<$count2; $j++) {
+            for ($j=0; $j<$count2; $j++) {
                 Logger::updateLine(" $i/$count : ".round($j*100/$count2, 2)." %");
                 $url = $infos[1][$j];
-                if($url[0] != 'h')
+                if ($url[0] != 'h') {
                     $url = 'https:'.$url;
+                }
                 $ch1 = curl_init();
                 curl_setopt($ch1, CURLOPT_URL, $url);
                 curl_setopt($ch1, CURLOPT_RETURNTRANSFER, 1);
@@ -68,13 +71,14 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
                 curl_close($ch1);
                 preg_match('/\<p class="description"\>(.*?)\<\/p\>/', $res1, $desc);
                 preg_match('/meta property="og:image" content="(.*?)"/', $res1, $img);
-                if(isset($desc[1]) && $desc[1][0] == '(') {
+                if (isset($desc[1]) && $desc[1][0] == '(') {
                     $genre = ltrim(explode(',', $desc[1])[0], '(');
                 } else {
                     $genre = "Inconnu";
                 }
-                if(isset($img[1]) && $img[1][0] != 'h')
+                if (isset($img[1]) && $img[1][0] != 'h') {
                     $img[1] = 'https:'.$img[1];
+                }
                 $currentProgram = array("startTime"=>strtotime($startDate." ".$infos[2][$j]),
                                     "title"=>$infos2[2][$j],
                                     "desc"=>@$desc[1],
@@ -82,7 +86,7 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
                                     "genre"=>$genre
                 );
                 $programs[] = $currentProgram;
-                if(isset($lastTime)) {
+                if (isset($lastTime)) {
                     $program = $programs[$lastTime];
                     $programObj = $this->channelObj->addProgram($program["startTime"], $currentProgram['startTime']);
                     $programObj->addTitle($program['title']);
@@ -95,6 +99,4 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
         }
         return $this->channelObj;
     }
-
-
 }

--- a/src/Component/Provider/Tele7Jours.php
+++ b/src/Component/Provider/Tele7Jours.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
@@ -8,7 +9,6 @@ use racacax\XmlTv\Component\ResourcePath;
 
 class Tele7Jours extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_tele7jours.json"), $priority ?? 0.6);
@@ -17,8 +17,9 @@ class Tele7Jours extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if (!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $channel_id = $this->channelsList[$channel];
 
 
@@ -38,12 +39,14 @@ class Tele7Jours extends AbstractProvider implements ProviderInterface
             $get = str_replace(');', '', $get);
             $get2 = $get;
             $get = json_decode($get, true);
-            if (!isset($get))
+            if (!isset($get)) {
                 return false;
+            }
 
             $pop = 0;
-            if(!isset($get["grille"]["aDiffusion"]))
+            if (!isset($get["grille"]["aDiffusion"])) {
                 return false;
+            }
             foreach ($get["grille"]["aDiffusion"] as $val) {
                 $h = $val["heureDif"];
                 $h = str_replace('h', ':', $h);
@@ -69,7 +72,7 @@ class Tele7Jours extends AbstractProvider implements ProviderInterface
             $program->addTitle($o[1]);
             $program->addDesc("Aucune description");
             $program->addCategory($o[3]);
-            if(!empty($o[2])) {
+            if (!empty($o[2])) {
                 $program->addSubtitle($o[2]);
             }
             $program->setIcon($o[4]);
@@ -82,6 +85,4 @@ class Tele7Jours extends AbstractProvider implements ProviderInterface
         }
         return $this->channelObj;
     }
-
-
 }

--- a/src/Component/Provider/TeleLoisirs.php
+++ b/src/Component/Provider/TeleLoisirs.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\Logger;
 use racacax\XmlTv\Component\ProviderInterface;
@@ -10,7 +10,6 @@ use racacax\XmlTv\Component\ResourcePath;
 
 class TeleLoisirs extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_teleloisirs.json"), $priority ?? 0.6);
@@ -19,8 +18,7 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
-        {
+        if (!$this->channelExists($channel)) {
             return false;
         }
         $channel_url = "https://www.programme-tv.net/programme/chaine/$date/".$this->getChannelsList()[$channel];
@@ -28,7 +26,7 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
         $lis = explode('<li class="gridChannel-listItem">', $res1);
         unset($lis[0]);
         $count = count($lis);
-        foreach($lis as $index => $li) {
+        foreach ($lis as $index => $li) {
             Logger::updateLine(" ".round($index*100/$count, 2)." %");
             $li = explode('</li>', $li)[0];
             preg_match('/href="(.*?)" title="(.*?)"/', $li, $titlehref);
@@ -37,13 +35,14 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
             $genre = trim(explode('</div>', explode('<div class="mainBroadcastCard-genre">', $li)[1] ?? '')[0]);
             $genreFormat = trim(explode('</p>', explode('<p class="mainBroadcastCard-format">', $li)[1] ?? '')[0]);
             $subtitle = @trim(explode('</p>', explode('<p class="mainBroadcastCard-subtitle">', $li)[1] ?? '')[0]);
-            $hour = explode('<', explode('>',explode('<p class="mainBroadcastCard-startingHour"', $li)[1] ?? '')[1])[0];
+            $hour = explode('<', explode('>', explode('<p class="mainBroadcastCard-startingHour"', $li)[1] ?? '')[1])[0];
             $duration = @explode('<', explode('<span class="mainBroadcastCard-durationContent">', $li)[1] ?? '')[0];
-            if(empty($duration))
+            if (empty($duration)) {
                 return false;
+            }
             $duration = str_replace('min', '', $duration);
             $duration = explode('h', $duration);
-            if(count($duration) == 2) {
+            if (count($duration) == 2) {
                 $duration = 60* intval($duration[1]) + 3600 * intval($duration[0]);
             } else {
                 $duration = 60 * intval($duration[0]);
@@ -52,20 +51,21 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
             $program = $this->channelObj->addProgram($startDate, $startDate + $duration);
             $detail = $this->getContentFromURL($titlehref[1]);
             $detailJson = @explode('<script type="application/ld+json">', $detail)[1];
-            if(isset($detailJson)) {
+            if (isset($detailJson)) {
                 $detailJson = json_decode(explode('</script>', $detailJson)[0], true);
                 $synopsis = $detailJson['description'] ?? '';
-                if(isset($detailJson['review'])) {
+                if (isset($detailJson['review'])) {
                     $synopsis.= "\nCritique : \n";
                     $synopsis.=@($detailJson['review']['description'] ?? $detailJson['review']['reviewBody']) ;
-                    if(isset($detailJson['review']['reviewRating']))
+                    if (isset($detailJson['review']['reviewRating'])) {
                         $synopsis.="\nNote : ".$detailJson['review']['reviewRating']['ratingValue']."/5";
+                    }
                 }
                 $program->setYear(@$detailJson['dateCreated']);
                 $program->setEpisodeNum(@$detailJson['partOfSeason']['seasonNumber'], @$detailJson['episodeNumber']);
-                foreach($detailJson as $key => $value) {
-                    if(in_array($key, ["actor", "director"])) {
-                        foreach($value as $person) {
+                foreach ($detailJson as $key => $value) {
+                    if (in_array($key, ["actor", "director"])) {
+                        foreach ($value as $person) {
                             $program->addCredit($person['name'], $key);
                         }
                     }
@@ -84,13 +84,14 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
                 $role = trim(explode('<', explode('"personCard-mediaLegendRole">', $participant)[1] ?? '')[0]);
                 if ($role == "Présentateur") {
                     $tag = "presenter";
-                } elseif($role == "Réalisateur") {
+                } elseif ($role == "Réalisateur") {
                     $tag = "director";
                 } else {
                     $tag = "guest";
                 }
-                if(!isset($detailJson))
+                if (!isset($detailJson)) {
                     $program->addCredit($name, $tag);
+                }
                 $synopsis .= $name . " ($role), ";
             }
             $synopsis = rtrim($synopsis, ', ');
@@ -100,8 +101,6 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
             $program->addCategory($genreFormat);
             $program->setIcon($img);
             $program->addDesc($synopsis);
-
-
         }
         return $this->channelObj;
     }

--- a/src/Component/Provider/TeleZ.php
+++ b/src/Component/Provider/TeleZ.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
@@ -19,18 +19,19 @@ class TeleZ extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
 
         $channelId = $this->getChannelsList()[$channel];
-        if(!isset(self::$cache_per_day[md5($date)])) {
+        if (!isset(self::$cache_per_day[md5($date)])) {
             $res3 = $this->getContentFromURL("https://api.telez.fr/schedule?full_day=1&date=$date");
             $json = json_decode($res3, true);
             self::$cache_per_day[md5($date)] = $json;
         }
         $array = self::$cache_per_day[md5($date)];
         foreach ($array['data'] as $c) {
-            if($c['channel']['id'] == $channelId) {
+            if ($c['channel']['id'] == $channelId) {
                 foreach ($c['programs'] as $program) {
                     $start = strtotime($program['onTime']);
                     $programObj = $this->channelObj->addProgram($start, $start + 60 * $program['duration']);

--- a/src/Component/Provider/Telecablesat.php
+++ b/src/Component/Provider/Telecablesat.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\Logger;
 use racacax\XmlTv\Component\ProviderInterface;
@@ -10,7 +10,6 @@ use racacax\XmlTv\Component\ResourcePath;
 
 class Telecablesat extends AbstractProvider implements ProviderInterface
 {
-
     private static $cache = []; // multiple channels are on the same page
     private static $BASE_URL = "https://tv-programme.telecablesat.fr";
     private $loopCounter = 0;
@@ -22,20 +21,20 @@ class Telecablesat extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
-        {
+        if (!$this->channelExists($channel)) {
             return false;
         }
         $channel_content = $this->getChannelsList()[$channel];
         $page = $channel_content['page'];
         $channel_id = $channel_content['id'];
         $channel_url = "https://tv-programme.telecablesat.fr/programmes-tele/?date=$date&page=$page";
-        if(!isset(self::$cache[md5($channel_url)])) {
+        if (!isset(self::$cache[md5($channel_url)])) {
             $res1 = $this->getContentFromURL($channel_url);
-            if(empty($res1)) {
+            if (empty($res1)) {
                 $this->loopCounter++;
-                if($this->loopCounter > 3)
+                if ($this->loopCounter > 3) {
                     return false;
+                }
                 Logger::updateLine(" \e[31mRate limited, waiting 30s ($this->loopCounter)\e[39m");
                 sleep(30);
                 return $this->constructEPG($channel, $date);
@@ -46,27 +45,28 @@ class Telecablesat extends AbstractProvider implements ProviderInterface
         $content = self::$cache[md5($channel_url)];
         preg_match_all('/logos_chaines\/(.*?).png" title="(.*?)"/', $content, $channels);
         $channel_index = array_search($channel_id, $channels[1]);
-        if($channel_index>=0) {
+        if ($channel_index>=0) {
             $channel_content = @explode('<div class="row">', explode("<div class='paging'>", $content)[0])[$channel_index+1];
-            if(isset($channel_content))  {
+            if (isset($channel_content)) {
                 preg_match_all('/data-start="(.*?)" data-end="(.*?)"/', $channel_content, $times);
                 preg_match_all('/data-src="(.*?)"/', $channel_content, $imgs);
                 preg_match_all('/<div class="hour-type">.*?<\/span>(.*?)<\/div>.*?<span class="title">(.*?)<\/span>/', $channel_content, $genresAndTitles);
                 preg_match_all('/class="link" href="(.*?)"/', $channel_content, $links);
                 $count = count($times[1]);
-                if(count($imgs[1]) != $count || count($genresAndTitles[1]) != $count || count($links[1]) != $count)
+                if (count($imgs[1]) != $count || count($genresAndTitles[1]) != $count || count($links[1]) != $count) {
                     return false;
+                }
                 $retry_counter = 0;
-                for($i=0; $i<$count; $i++) {
+                for ($i=0; $i<$count; $i++) {
                     Logger::updateLine(" ".round($i*100/$count, 2)." %");
                     $program = $this->channelObj->addProgram(intval($times[1][$i]), intval($times[2][$i]));
                     $program->addTitle(trim($genresAndTitles[2][$i] ?? ''));
                     $program->addCategory(trim($genresAndTitles[1][$i] ?? ''));
                     $program->setIcon("https:".$imgs[1][$i]);
                     $content = $this->getContentFromURL(self::$BASE_URL.$links[1][$i]);
-                    if(empty($content)) {
+                    if (empty($content)) {
                         $retry_counter++;
-                        if($retry_counter > 3) {
+                        if ($retry_counter > 3) {
                             $retry_counter = 0;
                             continue;
                         }
@@ -78,15 +78,15 @@ class Telecablesat extends AbstractProvider implements ProviderInterface
                     }
                     $content = explode('<div class="top-menu">', $content)[1];
                     $content = explode('<h2>Prochains épisodes</h2>', $content)[0];
-                    $content = str_replace("<br>","\n", $content);
-                    $content = str_replace("<br />","\n", $content);
+                    $content = str_replace("<br>", "\n", $content);
+                    $content = str_replace("<br />", "\n", $content);
                     preg_match('/class="age-(.*?)"/', $content, $csa);
-                    if(isset($csa[1])) {
+                    if (isset($csa[1])) {
                         $program->setRating("-".$csa[1]);
                     }
                     preg_match('/itemprop="episodeNumber">(.*?)<\/span>/s', $content, $season);
                     preg_match('/<\/span>\\((.*?)\/<span itemprop="numberOfEpisodes">/s', $content, $episode);
-                    $program->setEpisodeNum(@$season[1],@$episode[1]);
+                    $program->setEpisodeNum(@$season[1], @$episode[1]);
                     $critique = @explode('<h2>Critique</h2>', $content)[1] ?? '';
                     preg_match("/<p>(.*?)</s", $critique, $critique);
                     $resume = @explode('<h2>Résumé</h2>', $content)[1];
@@ -96,34 +96,36 @@ class Telecablesat extends AbstractProvider implements ProviderInterface
                     preg_match_all('/span itemprop="actor">(.*?)<\/span>(.*?)</s', $content, $actors);
                     preg_match('/<div class="label w40">.*?Présentateur.*?<\/div>.*?<div class="text w60">(.*?)<\/div>/s', $content, $presenter);
                     preg_match('/<div class="overlayerpicture">.*?<img class="lazy" alt=".*?" data-src="(.*?)"/s', $content, $imgs);
-                    if(isset($subtitle[1]))
+                    if (isset($subtitle[1])) {
                         $program->addSubtitle($subtitle[1]);
-                    if(isset($imgs[1]))
+                    }
+                    if (isset($imgs[1])) {
                         $program->setIcon("https:".$imgs[1]);
+                    }
                     $desc = '';
-                    if(isset($resume[1])) {
+                    if (isset($resume[1])) {
                         $desc.=trim($resume[1] ?? '')."\n\n";
                     }
-                    if(isset($critique[1])) {
+                    if (isset($critique[1])) {
                         $desc.="Critique : ".trim($critique[1])."\n\n";
                     }
-                    if(isset($directors[1])) {
+                    if (isset($directors[1])) {
                         $directors_split = explode(',', $directors[1]);
                         $desc.= "Réalisateur(s) : ".trim($directors[1])."\n";
-                        foreach($directors_split as $director) {
+                        foreach ($directors_split as $director) {
                             $program->addCredit(trim($director), "director");
                         }
                     }
-                    if(isset($presenter[1])) {
+                    if (isset($presenter[1])) {
                         $presenter_split = explode(',', $presenter[1]);
                         $desc.= "Présentateur(s) : ".trim($presenter[1])."\n";
-                        foreach($presenter_split as $presenter) {
+                        foreach ($presenter_split as $presenter) {
                             $program->addCredit(trim($presenter), "presenter");
                         }
                     }
-                    if(!empty($actors[1])) {
+                    if (!empty($actors[1])) {
                         $desc.="Acteurs : ";
-                        for($j=0; $j<count($actors[1]); $j++) {
+                        for ($j=0; $j<count($actors[1]); $j++) {
                             $program->addCredit(trim($actors[1][$j]), "actor");
                             $desc.=trim($actors[1][$j].$actors[2][$j])." ";
                         }
@@ -133,7 +135,6 @@ class Telecablesat extends AbstractProvider implements ProviderInterface
                     $retry_counter = 0;
                 }
             }
-
         }
         return $this->channelObj;
     }

--- a/src/Component/Provider/Telerama.php
+++ b/src/Component/Provider/Telerama.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
 
-
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
@@ -36,8 +35,9 @@ class Telerama extends AbstractProvider implements ProviderInterface
         if (!isset($date)) {
             $date = date('Y-m-d');
         }
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $channel_id = $this->channelsList[$channel];
 
 
@@ -67,7 +67,7 @@ class Telerama extends AbstractProvider implements ProviderInterface
                     $program->setEpisodeNum($donnee["serie"]["saison"], $donnee["serie"]["numero_episode"]);
                 }
                 if (isset($donnee["soustitre"]) && !empty($donnee["soustitre"])) {
-                   $program->addSubtitle($donnee["soustitre"]);
+                    $program->addSubtitle($donnee["soustitre"]);
                 }
                 if (isset($donnee["vignettes"]["grande169"])) {
                     $program->setIcon($donnee["vignettes"]["grande169"]);
@@ -137,9 +137,9 @@ class Telerama extends AbstractProvider implements ProviderInterface
                     }
                 }
                 $program->addTitle($donnee["titre"]);
-                $program->addDesc(!empty($descri)? $descri: 'Pas de description');
+                $program->addDesc(!empty($descri) ? $descri : 'Pas de description');
                 $program->addCategory($donnee["genre_specifique"]);
-                if($donnee["csa"] == "TP") {
+                if ($donnee["csa"] == "TP") {
                     $rating = "Tout public";
                 } else {
                     $rating = "-".$donnee["csa"];
@@ -150,5 +150,4 @@ class Telerama extends AbstractProvider implements ProviderInterface
         }
         return false;
     }
-
 }

--- a/src/Component/Provider/UltraNature.php
+++ b/src/Component/Provider/UltraNature.php
@@ -1,15 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 class UltraNature extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_ultranature.json"), $priority ?? 0.1);
@@ -18,8 +17,9 @@ class UltraNature extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(@$this->channelsList[$channel]!="UltraNature")
+        if (@$this->channelsList[$channel]!="UltraNature") {
             return false;
+        }
         $days = array(
             'Mon'=> array('0000 || Voyage','0130 || Programme inconnu','0700 || Paysages','0830 || Animaux','1030 || Sports extrêmes','1200 || Découverte','1330 || Sports extrêmes','1530 || Découverte','1730 || Animaux','1900 || Voyage','2100 || Animaux','2300 || Sports extrêmes'),
             'Tue'=> array('0000 || Découverte','0130 || Programme inconnu','0700 || Paysages','0830 || Découverte','1030 || Voyage','1200 || Animaux','1330 || Animaux','1530 || Sports extrêmes','1730 || Sports extrêmes','1900 || Découverte','2100 || Découverte','2300 || Voyage'),
@@ -29,21 +29,20 @@ class UltraNature extends AbstractProvider implements ProviderInterface
             'Sat'=> array('0000 || Découverte','0130 || Programme inconnu','0700 || Paysages','0830 || Animaux','1030 || Animaux','1200 || Sports extrêmes','1330 || Découverte','1530 || Sports extrêmes','1730 || Voyage','1900 || Découverte','2100 || Animaux','2300 || Animaux'),
             'Sun'=> array('0000 || Sports extrêmes','0130 || Programme inconnu','0700 || Paysages','0830 || Sports extrêmes','1030 || Découverte','1200 || Voyage','1330 || Animaux','1530 || Animaux','1730 || Découverte','1900 || Sports extrêmes','2100 || Sports extrêmes','2300 || Animaux')
         );
-        $d = $days[date('D',strtotime($date))];
-        $date2 = date('Ymd',strtotime($date));
-        for($j=0;$j<count($d);$j++)
-        {
-            $st = explode(' || ',$d[$j]);
-            if(isset($d[$j+1])) {
+        $d = $days[date('D', strtotime($date))];
+        $date2 = date('Ymd', strtotime($date));
+        for ($j=0;$j<count($d);$j++) {
+            $st = explode(' || ', $d[$j]);
+            if (isset($d[$j+1])) {
                 $st2 = explode(' || ', $d[$j + 1])[0];
             } else {
                 $st2 = '0000';
             }
             $d1 = $date2.$st[0].'00 '.date('O');
-            if($st2!='0000') {
+            if ($st2!='0000') {
                 $d2 = $date2 . $st2 . '00 ' . date('O');
             } else {
-                $d2 = date('Ymd',strtotime($date)+86400) . $st2 . '00 ' . date('O');
+                $d2 = date('Ymd', strtotime($date)+86400) . $st2 . '00 ' . date('O');
             }
             $program = $this->channelObj->addProgram(strtotime($d1), strtotime($d2));
             $program->addTitle($st[1]);

--- a/src/Component/Provider/ViniPF.php
+++ b/src/Component/Provider/ViniPF.php
@@ -1,8 +1,8 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\Logger;
 use racacax\XmlTv\Component\ProviderInterface;
@@ -20,15 +20,16 @@ class ViniPF extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $debut = strtotime($date); // to be synchronized with Paris timezone to avoid overlaping on french channels if multiple providers
         date_default_timezone_set("Pacific/Tahiti");
         $count = 12;
-        for($i=0; $i <$count; $i++) {
+        for ($i=0; $i <$count; $i++) {
             Logger::updateLine(" ".round($i*100/$count, 2)." %");
-            $dateDebut = '{"dateDebut":"'.date('c',$debut + 3600*2*$i).'"}';
-            if(!isset(self::$cache_per_day[md5($dateDebut)])) {
+            $dateDebut = '{"dateDebut":"'.date('c', $debut + 3600*2*$i).'"}';
+            if (!isset(self::$cache_per_day[md5($dateDebut)])) {
                 $ch3 = curl_init();
                 curl_setopt($ch3, CURLOPT_URL, 'https://programme-tv.vini.pf/programmesJSON');
                 curl_setopt($ch3, CURLOPT_RETURNTRANSFER, 1);
@@ -44,9 +45,9 @@ class ViniPF extends AbstractProvider implements ProviderInterface
                 self::$cache_per_day[md5($dateDebut)] = $json;
             }
             $array = self::$cache_per_day[md5($dateDebut)];
-            foreach($array["programmes"] as $viniChannel) {
-                if($viniChannel["nid"] == $this->channelsList[$channel]) {
-                    foreach($viniChannel["programmes"] as $programme) {
+            foreach ($array["programmes"] as $viniChannel) {
+                if ($viniChannel["nid"] == $this->channelsList[$channel]) {
+                    foreach ($viniChannel["programmes"] as $programme) {
                         $program = $this->channelObj->addProgram($programme["timestampDeb"], $programme['timestampFin']);
                         $program->addTitle($programme['titreP']);
                         $program->addSubtitle($programme['legendeP']);

--- a/src/Component/Provider/Voo.php
+++ b/src/Component/Provider/Voo.php
@@ -1,15 +1,14 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
-
 
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
 
 class Voo extends AbstractProvider implements ProviderInterface
 {
-
     public function __construct(?float $priority = null, array $extraParam = [])
     {
         parent::__construct(ResourcePath::getInstance()->getChannelPath("channels_voo.json"), $priority ?? 0.85);
@@ -18,8 +17,9 @@ class Voo extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         parent::constructEPG($channel, $date);
-        if(!$this->channelExists($channel))
+        if (!$this->channelExists($channel)) {
             return false;
+        }
         $date_start = date('Y-m-d', strtotime($date)).'T00:00:00Z';
         $date_end = date('Y-m-d', strtotime($date) + 86400).'T02:00:00Z';
         //$end = strtotime($date);
@@ -51,5 +51,4 @@ class Voo extends AbstractProvider implements ProviderInterface
         }
         return $this->channelObj;
     }
-
 }

--- a/src/Component/ProviderInterface.php
+++ b/src/Component/ProviderInterface.php
@@ -1,12 +1,13 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
 
 use racacax\XmlTv\ValueObject\Channel;
 
-interface ProviderInterface {
-
+interface ProviderInterface
+{
     public function __construct();
 
     /**
@@ -16,5 +17,5 @@ interface ProviderInterface {
      */
     public function constructEPG(string $channel, string $date);
 
-    static function getPriority(): float;
+    public static function getPriority(): float;
 }

--- a/src/Component/ResourcePath.php
+++ b/src/Component/ResourcePath.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
@@ -60,5 +61,4 @@ class ResourcePath
             ]
         );
     }
-
 }

--- a/src/Component/Utils.php
+++ b/src/Component/Utils.php
@@ -1,10 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
 
-class Utils {
-
+class Utils
+{
     /**
      * @var class-string<ProviderInterface>[]
      */
@@ -12,7 +13,7 @@ class Utils {
 
     public static function getProviders()
     {
-        if(isset(self::$providers)){
+        if (isset(self::$providers)) {
             return self::$providers;
         }
 

--- a/src/Component/XmlExporter.php
+++ b/src/Component/XmlExporter.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\Component;
@@ -8,7 +9,6 @@ use racacax\XmlTv\ValueObject\Channel;
 
 class XmlExporter
 {
-
     /**
      * @var XmlFormatter
      */
@@ -58,19 +58,17 @@ class XmlExporter
         $this->content->documentElement->setAttribute('source-info-name', "XML TV Fr");
         $this->content->documentElement->setAttribute('generator-info-name', "XML TV Fr");
         $this->content->documentElement->setAttribute('generator-info-url', "https://github.com/racacax/XML-TV-Fr");
-
     }
     public function addChannel($channelKey, $name, $icon)
     {
-
         $channel = new \SimpleXMLElement('<channel/>');
         $channel->addAttribute('id', $channelKey);
         $channel->addChild(
             'display-name',
-            str_replace('"','&quot;',htmlspecialchars($name, ENT_XML1))
+            str_replace('"', '&quot;', htmlspecialchars($name, ENT_XML1))
         );
 
-        if(!empty($icon)){
+        if (!empty($icon)) {
             $channel->addChild('icon')->addAttribute('src', $icon);
         }
         $this->content->documentElement->appendChild($this->content->importNode(dom_import_simplexml($channel), true));
@@ -79,7 +77,7 @@ class XmlExporter
     public function addProgramsAsString(string $programs)
     {
         $root = simplexml_load_string("<root>$programs</root>");
-        foreach($root->children() as $child) {
+        foreach ($root->children() as $child) {
             $this->content->documentElement->appendChild($this->content->importNode(dom_import_simplexml($child), true));
         }
     }
@@ -87,12 +85,12 @@ class XmlExporter
     public function stopExport()
     {
         $this->content->loadXML($this->content->saveXML());
-        if($this->content->validate()) {
+        if ($this->content->validate()) {
             Logger::log("\e[34m[EXPORT] \e[32mXML Valide\e[39m\n");
         } else {
             Logger::log("\e[34m[EXPORT] \e[31mXML non valide selon xmltv.dtd\e[39m\n");
         }
-        $content = str_replace('"resources/validation/xmltv.dtd"', '"xmltv.dtd"',$this->content->saveXML());
+        $content = str_replace('"resources/validation/xmltv.dtd"', '"xmltv.dtd"', $this->content->saveXML());
 
         if (in_array('xml', $this->outputFormat) || in_array('xz', $this->outputFormat)) {
             file_put_contents($this->filePath, $content);
@@ -104,12 +102,12 @@ class XmlExporter
             Logger::log("\e[34m[EXPORT] \e[39mGZ : \e[32mOK\e[39m ($this->filePath.'.gz')\n");
         }
         $split_fp = explode('.', $this->filePath);
-        if(count($split_fp) == 1) {
+        if (count($split_fp) == 1) {
             $lengthToRemove = 0;
         } else {
             $lengthToRemove = strlen(".".end($split_fp));
         }
-        $shortenedFilePath = substr($this->filePath,0, -$lengthToRemove);
+        $shortenedFilePath = substr($this->filePath, 0, -$lengthToRemove);
         if (in_array('zip', $this->outputFormat)) {
             $filename = $shortenedFilePath.'.zip';
             Logger::log("\e[34m[EXPORT] \e[39mCompression du XMLTV en ZIP...\n");
@@ -125,7 +123,7 @@ class XmlExporter
         }
 
         if (in_array('xz', $this->outputFormat)) {
-            if(empty($this->sevenZipPath)) {
+            if (empty($this->sevenZipPath)) {
                 Logger::log("\e[34m[EXPORT] \e[31mImpossible d'exporter en XZ (chemin de 7zip non défini)\e[39m\n");
                 return;
             }
@@ -139,5 +137,4 @@ class XmlExporter
             }
         }
     }
-
 }

--- a/src/Component/XmlFormatter.php
+++ b/src/Component/XmlFormatter.php
@@ -31,8 +31,8 @@ class XmlFormatter
             $content[] = '<!-- ' . get_class($provider) . ' -->';
         }
 
-        foreach($channel->getPrograms() as $program) {
-            $content[] = '<programme start="'.date('YmdHis O',$program->getStart()).'" stop="'.date('YmdHis O',$program->getEnd()).'" channel="'.$channel->getId().'">';
+        foreach ($channel->getPrograms() as $program) {
+            $content[] = '<programme start="'.date('YmdHis O', $program->getStart()).'" stop="'.date('YmdHis O', $program->getEnd()).'" channel="'.$channel->getId().'">';
             $content[] = $this->listToMark($program->getTitles(), "title", "Aucun titre");
             $content[] = $this->listToMark($program->getSubtitles(), "sub-title");
             $content[] = $this->listToMark($program->getDescs(), "desc", "Aucune description");
@@ -44,19 +44,19 @@ class XmlFormatter
             //$content[] = $this->buildYear($program->getYear());
 
             $content[]= '</programme>';
-
         }
 
         return implode("\n", array_filter($content));
     }
 
 
-    private function listToMark($list, $tagName, $stringIfEmpty = null) {
+    private function listToMark($list, $tagName, $stringIfEmpty = null)
+    {
         $content = [];
-        foreach($list as $elem) {
+        foreach ($list as $elem) {
             $content[]= '<'.$tagName.' lang="'.$elem["lang"].'">' . $this->stringAsXML($elem['name']) . "</$tagName>";
         }
-        if(empty($content) && isset($stringIfEmpty)) {
+        if (empty($content) && isset($stringIfEmpty)) {
             $content[]= '<'.$tagName.' lang="fr">' . $this->stringAsXML($stringIfEmpty) . "</$tagName>";
         }
         return trim(implode("\n", $content));
@@ -64,7 +64,7 @@ class XmlFormatter
 
     public function buildCredits(?array $credits): string
     {
-        if(empty($this->credits)) {
+        if (empty($this->credits)) {
             return '';
         }
 
@@ -82,7 +82,7 @@ class XmlFormatter
      */
     public function buildEpisodeNum($episodeNum): string
     {
-        if(!empty($episodeNum)) {
+        if (!empty($episodeNum)) {
             return '<episode-num system="xmltv_ns">'.$episodeNum.".</episode-num>";
         }
         return '';
@@ -93,7 +93,7 @@ class XmlFormatter
      */
     public function buildIcon(?string $icon): string
     {
-        if(isset($icon) && strlen($icon) > 0) {
+        if (isset($icon) && strlen($icon) > 0) {
             return '<icon src="' . $this->stringAsXML($icon) . '" />';
         }
         return "";
@@ -104,7 +104,7 @@ class XmlFormatter
      */
     public function buildYear(?string $year): string
     {
-        if(!isset($year)){
+        if (!isset($year)) {
             return '';
         }
 
@@ -113,7 +113,7 @@ class XmlFormatter
 
     public function buildRating($rating): string
     {
-        if(!isset($rating)) {
+        if (!isset($rating)) {
             return '';
         }
         $pictoUrl = $this->ratingPicto->getPictoFromRatingSystem($rating[0], $rating[1]);
@@ -123,7 +123,8 @@ class XmlFormatter
                '</rating>';
     }
 
-    private function stringAsXML($string) {
-        return str_replace('"','&quot;',htmlspecialchars($string, ENT_XML1));
+    private function stringAsXML($string)
+    {
+        return str_replace('"', '&quot;', htmlspecialchars($string, ENT_XML1));
     }
 }

--- a/src/Configurator.php
+++ b/src/Configurator.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv;
@@ -225,8 +226,7 @@ class Configurator
 
     public static function initFromConfigFile(string $filePath): self
     {
-
-        if (!file_exists($filePath)){
+        if (!file_exists($filePath)) {
             throw new \Exception('Config file not found');
         }
         $data = json_decode(file_get_contents($filePath), true);
@@ -235,10 +235,10 @@ class Configurator
 
         Logger::log("\e[36m[CHARGEMENT] \e[39mListe des paramètres : ");
         foreach ($data as $key => $value) {
-            if(is_array($value)) {
+            if (is_array($value)) {
                 $value = json_encode($value);
             }
-            if(is_bool($value)) {
+            if (is_bool($value)) {
                 $value = $value ? 'true' : 'false';
             }
             Logger::log("\e[95m($key) \e[39m=> \e[33m$value\e[39m, ");
@@ -299,18 +299,17 @@ class Configurator
     /**
      * @return ProviderInterface[]
      */
-    public function getProviders():array
+    public function getProviders(): array
     {
         $providersClass = Utils::getProviders();
         $providersObject = [];
-        foreach($providersClass as $providerClass) {
+        foreach ($providersClass as $providerClass) {
             $tmp = explode('\\', $providerClass);
             $name = end($tmp);
             $providersObject[] = new $providerClass($this->customPriorityOrders[$name] ?? null, $this->extraParams);
-
         }
 
-        usort($providersObject, function (ProviderInterface $providerA, ProviderInterface $providerB){
+        usort($providersObject, function (ProviderInterface $providerA, ProviderInterface $providerB) {
             return $providerB::getPriority() <=> $providerA::getPriority();
         });
 
@@ -332,7 +331,4 @@ class Configurator
     {
         return $this->cacheMaxDays;
     }
-
-
-
 }

--- a/src/StaticComponent/ChannelInformation.php
+++ b/src/StaticComponent/ChannelInformation.php
@@ -1,11 +1,12 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\StaticComponent;
 
 use racacax\XmlTv\Component\ResourcePath;
 
-final  class ChannelInformation
+final class ChannelInformation
 {
     private static $instance;
     private $channelInfo;
@@ -33,5 +34,4 @@ final  class ChannelInformation
     {
         return $this->channelInfo[$channelKey]['name'] ?? null;
     }
-
 }

--- a/src/StaticComponent/RatingPicto.php
+++ b/src/StaticComponent/RatingPicto.php
@@ -1,4 +1,5 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\StaticComponent;
@@ -22,11 +23,10 @@ final class RatingPicto
 
     public function getPictoFromRatingSystem(?string $rating, ?string $system): ?string
     {
-        if(!isset($rating) || !isset($system)) {
+        if (!isset($rating) || !isset($system)) {
             return null;
         }
 
         return $this->ratingPictoInfo[strtolower($system)][strtolower($rating)] ?? null;
     }
-
 }

--- a/src/ValueObject/Channel.php
+++ b/src/ValueObject/Channel.php
@@ -1,9 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\ValueObject;
 
-class Channel {
+class Channel
+{
     /**
      * @var string
      */
@@ -46,7 +48,7 @@ class Channel {
         return $this->name;
     }
 
-    public function getIcon() : ?string
+    public function getIcon(): ?string
     {
         return $this->icon;
     }
@@ -72,11 +74,13 @@ class Channel {
         return $this->programs;
     }
 
-    public function getProgramCount() {
+    public function getProgramCount()
+    {
         return count($this->getPrograms());
     }
 
-    public function popLastProgram() {
+    public function popLastProgram()
+    {
         return array_pop($this->programs);
     }
 }

--- a/src/ValueObject/DummyChannel.php
+++ b/src/ValueObject/DummyChannel.php
@@ -1,18 +1,19 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\ValueObject;
 
-class DummyChannel extends Channel {
+class DummyChannel extends Channel
+{
     public function __construct($id, string $icon, string $name, $date)
     {
         parent::__construct($id, $icon, $name);
 
-        for($i=0; $i<12; $i++) {
+        for ($i=0; $i<12; $i++) {
             $time = strtotime($date)+$i*2*3600;
             $program = $this->addProgram($time, $time + 2 * 3600);
             $program->addTitle("Aucun programme");
         }
     }
-
 }

--- a/src/ValueObject/Program.php
+++ b/src/ValueObject/Program.php
@@ -1,9 +1,11 @@
 <?php
+
 declare(strict_types=1);
 
 namespace racacax\XmlTv\ValueObject;
 
-class Program {
+class Program
+{
     private $titles;
     private $descs;
     private $categories;
@@ -48,8 +50,9 @@ class Program {
      */
     public function addTitle($title, $lang="fr"): void
     {
-        if(!empty($title))
+        if (!empty($title)) {
             $this->titles[] = array("name"=>$title, "lang"=>$lang);
+        }
     }
 
     /**
@@ -67,9 +70,10 @@ class Program {
      */
     public function addCredit($name, $type): void
     {
-        if(!empty($name)) {
-            if(empty($type))
+        if (!empty($name)) {
+            if (empty($type)) {
                 $type = "guest";
+            }
             $this->credits[] = array("name" => $name, "type" => $type);
         }
     }
@@ -89,8 +93,9 @@ class Program {
      */
     public function addDesc($desc, $lang="fr"): void
     {
-        if(!empty($desc))
+        if (!empty($desc)) {
             $this->descs[] = array("name"=>$desc, "lang"=>$lang);
+        }
     }
 
     /**
@@ -106,8 +111,9 @@ class Program {
      */
     public function addCategory($category, $lang="fr"): void
     {
-        if(!empty($category))
+        if (!empty($category)) {
             $this->categories[] = array("name"=>$category, "lang"=>$lang);
+        }
     }
 
     /**
@@ -160,14 +166,17 @@ class Program {
      */
     public function setEpisodeNum($season, $episode): void
     {
-        if(!isset($season) && !isset($episode))
+        if (!isset($season) && !isset($episode)) {
             return;
+        }
         $season = @(intval($season)-1);
         $episode = @(intval($episode)-1);
-        if($season < 0)
+        if ($season < 0) {
             $season = 0;
-        if($episode < 0)
+        }
+        if ($episode < 0) {
             $episode = 0;
+        }
         $this->episode_num = $season.'.'.$episode;
     }
 
@@ -186,8 +195,9 @@ class Program {
      */
     public function addSubtitle($subtitle, $lang="fr"): void
     {
-        if(!empty($subtitle))
+        if (!empty($subtitle)) {
             $this->subtitles[] = array('name'=>$subtitle, "lang"=>$lang);
+        }
     }
 
     /**
@@ -221,8 +231,8 @@ class Program {
      */
     public function setYear($year): void
     {
-        if(!empty($year))
+        if (!empty($year)) {
             $this->year = $year;
+        }
     }
-
 }


### PR DESCRIPTION
Ajout d'un simple [cs-fixer](https://github.com/FriendsOfPHP/PHP-CS-Fixer)

Il permet d'avoir les même norme de codage sur tout les fichiers.
Pour l'utiliser, il suffit de faire : 
```SHELL
make quality
```
ou 
```SHELL
bin/php-cs-fixer fix src
```
J'ai aussi suprimer franceO qui n'existe plus.