### PR TITLE
Ajout Canal + Foot et autre

### DIFF
--- a/resources/channel_config/channels_mycanal.json
+++ b/resources/channel_config/channels_mycanal.json
@@ -222,6 +222,7 @@
   "CanalPlusCinema.fr": 198,
   "CanalPlusDecale.fr": 257,
   "CanalPlusSport360.fr": 83,
+  "CanalPlusFoot.fr": 19,
   "PlanetePlus.fr": 270,
   "CinePlusPremier.fr": 322,
   "CinePlusEmotion.fr": 396,

--- a/resources/channel_config/channels_teleloisirs.json
+++ b/resources/channel_config/channels_teleloisirs.json
@@ -37,6 +37,8 @@
   "CanalPlusDecale.fr": "programme-canalplus-decale-36.html",
   "CanalPlusSport360.fr": "programme-canalplus-sport-360-11509.html",
   "CanalPlusFoot.fr": "programme-canalplus-foot-11508.html",
+  "CanalPlusPremierLeague.fr": "programme-canalplus-premier-league-10506.html",
+  "CanalPlusFormula1.fr": "programme-canalplus-formula-1-10503.html",
   "beINSPORTS1.fr": "programme-bein-sports-1-183.html",
   "beINSPORTS2.fr": "programme-bein-sports-2-184.html",
   "beINSPORTS3.fr": "programme-bein-sports-3-265.html",

--- a/resources/channel_config/channels_teleloisirs.json
+++ b/resources/channel_config/channels_teleloisirs.json
@@ -36,6 +36,7 @@
   "CanalPlusKIDS.fr": "programme-canalplus-kids-149.html",
   "CanalPlusDecale.fr": "programme-canalplus-decale-36.html",
   "CanalPlusSport360.fr": "programme-canalplus-sport-360-11509.html",
+  "CanalPlusFoot.fr": "programme-canalplus-foot-11508.html",
   "beINSPORTS1.fr": "programme-bein-sports-1-183.html",
   "beINSPORTS2.fr": "programme-bein-sports-2-184.html",
   "beINSPORTS3.fr": "programme-bein-sports-3-265.html",

--- a/resources/config/default_channels.json
+++ b/resources/config/default_channels.json
@@ -42,6 +42,7 @@
   "CanalPlusCinemaDROM.fr": {},
   "CanalPlusDecale.fr": {},
   "CanalPlusSport360.fr": {},
+  "CanalPlusFoot.fr": {},
   "CanalPlusFamily.fr": {},
   "CanalJ.fr": {},
   "CanalpartageTNTIDF.fr": {},

--- a/resources/information/default_channels_infos.json
+++ b/resources/information/default_channels_infos.json
@@ -898,6 +898,10 @@
     "name": "Canal+ Sport 360",
     "icon": "https:\/\/upload.wikimedia.org\/wikipedia\/commons\/6\/64\/Canal%2BSport_360.png"
   },
+  "CanalPlusFoot.fr": {
+    "name": "Canal+ Foot",
+    "icon": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/eb/Canal%2BFoot.png/220px-Canal%2BFoot.png"
+  },
   "CanalPlusDocs.fr": {
     "name": "Canal+ Docs",
     "icon": "https:\/\/upload.wikimedia.org\/wikipedia\/commons\/2\/27\/Canal%2B_Docs.png"


### PR DESCRIPTION
Ajout:

- Canal+ première league sur le Teleloisir
- Canal+ formule 1 sur Teleloisirs
- Canal + foot sur Teleloisirs
- Canal + foot sur MyCanal