### PR TITLE
Fix getcredits

### DIFF
--- a/src/Component/Provider/AmazonPrime.php
+++ b/src/Component/Provider/AmazonPrime.php
@@ -46,8 +46,12 @@ class AmazonPrime extends AbstractProvider implements ProviderInterface
             foreach($programs as $program) {
                 preg_match('/aria-label="(.*?)"/', $program, $title);
                 preg_match('/href="(.*?)"/', $program, $detail);
-                $title = $title[1];
-                $detail = $this->getContentFromURL("https://www.primevideo.com".$detail[1]);
+                $title = $title[1] ?? "Aucun titre";
+                if(isset($detail[1])) {
+                    $detail = $this->getContentFromURL("https://www.primevideo.com".$detail[1]);
+                } else {
+                    continue;
+                }
                 preg_match('/"pageDateTimeBadge":"(.*?)"/', $detail, $time);
                 preg_match('/"location":"(.*?)"/', $detail, $location);
                 preg_match('/"synopsis":"(.*?)"/', $detail, $synopsis);

--- a/src/Component/Provider/Bouygues.php
+++ b/src/Component/Provider/Bouygues.php
@@ -74,29 +74,7 @@ class Bouygues extends AbstractProvider implements ProviderInterface
             $programObj = new Program(strtotime($program['startTime']), strtotime($program['endTime']));
             if (isset($program['programInfo']['character'])) {
                 foreach ($program['programInfo']['character'] as $intervenant) {
-                    $libelle = 'guest';
-                    if ($intervenant['function'] == 'Présentateur vedette' || $intervenant['function'] == 'Autre présentateur') {
-                        $libelle = 'presenter';
-                    }
-                    if($intervenant['function'] == "Producteur"){
-                        $libelle = 'producer';
-                    }
-                    if ($intervenant['function'] == 'Acteur') {
-                        $libelle = 'actor';
-                    }
-                    if ($intervenant['function'] == 'Réalisateur') {
-                        $libelle = 'director';
-                    }
-                    if ($intervenant['function'] == 'Scénariste' || $intervenant['function'] == 'Origine Scénario' || $intervenant['function'] == 'Scénario') {
-                        $libelle = 'writer';
-                    }
-                    if ($intervenant['function'] == 'Créateur') {
-                        $libelle = 'editor';
-                    }
-                    if ($intervenant['function'] == 'Musique') {
-                        $libelle = 'composer';
-                    }
-                    $programObj->addCredit($intervenant['firstName'] . ' ' . $intervenant['lastName'], $libelle);
+                    $programObj->addCredit($intervenant['firstName'] . ' ' . $intervenant['lastName'], $intervenant['function']);
                 }
             }
             $programObj->addTitle($program['programInfo']['longTitle']);

--- a/src/Component/Provider/Bouygues.php
+++ b/src/Component/Provider/Bouygues.php
@@ -123,7 +123,6 @@ class Bouygues extends AbstractProvider implements ProviderInterface
             'startTime'=>$date->format('Y-m-d\T04:00:00\Z'),
             'endTime'=>$date->modify('+1 days')->format('Y-m-d\T03:59:59\Z')
         ];
-        var_dump('http://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param));
         return 'http://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param);
     }
 }

--- a/src/Component/Provider/Bouygues.php
+++ b/src/Component/Provider/Bouygues.php
@@ -72,6 +72,33 @@ class Bouygues extends AbstractProvider implements ProviderInterface
                 }
             }
             $programObj = new Program(strtotime($program['startTime']), strtotime($program['endTime']));
+            if (isset($program['programInfo']['character'])) {
+                foreach ($program['programInfo']['character'] as $intervenant) {
+                    $libelle = 'guest';
+                    if ($intervenant['function'] == 'Présentateur vedette' || $intervenant['function'] == 'Autre présentateur') {
+                        $libelle = 'presenter';
+                    }
+                    if($intervenant['function'] == "Producteur"){
+                        $libelle = 'producer';
+                    }
+                    if ($intervenant['function'] == 'Acteur') {
+                        $libelle = 'actor';
+                    }
+                    if ($intervenant['function'] == 'Réalisateur') {
+                        $libelle = 'director';
+                    }
+                    if ($intervenant['function'] == 'Scénariste' || $intervenant['function'] == 'Origine Scénario' || $intervenant['function'] == 'Scénario') {
+                        $libelle = 'writer';
+                    }
+                    if ($intervenant['function'] == 'Créateur') {
+                        $libelle = 'editor';
+                    }
+                    if ($intervenant['function'] == 'Musique') {
+                        $libelle = 'composer';
+                    }
+                    $programObj->addCredit($intervenant['firstName'] . ' ' . $intervenant['lastName'], $libelle);
+                }
+            }
             $programObj->addTitle($program['programInfo']['longTitle']);
             $programObj->addSubtitle(@$program['programInfo']['secondaryTitle']);
             $programObj->addDesc(@$program['programInfo']['longSummary'] ?? @$program['programInfo']['shortSummary']);
@@ -96,7 +123,7 @@ class Bouygues extends AbstractProvider implements ProviderInterface
             'startTime'=>$date->format('Y-m-d\T04:00:00\Z'),
             'endTime'=>$date->modify('+1 days')->format('Y-m-d\T03:59:59\Z')
         ];
-
+        var_dump('http://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param));
         return 'http://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param);
     }
 }

--- a/src/Component/Provider/Bouygues.php
+++ b/src/Component/Provider/Bouygues.php
@@ -74,7 +74,7 @@ class Bouygues extends AbstractProvider implements ProviderInterface
             $programObj = new Program(strtotime($program['startTime']), strtotime($program['endTime']));
             if (isset($program['programInfo']['character'])) {
                 foreach ($program['programInfo']['character'] as $intervenant) {
-                    $programObj->addCredit($intervenant['firstName'] . ' ' . $intervenant['lastName'], $intervenant['function']);
+                    $programObj->addCredit($intervenant['firstName'] . ' ' . $intervenant['lastName'], $this->getCreditType($intervenant['function']));
                 }
             }
             $programObj->addTitle($program['programInfo']['longTitle']);
@@ -102,5 +102,41 @@ class Bouygues extends AbstractProvider implements ProviderInterface
             'endTime'=>$date->modify('+1 days')->format('Y-m-d\T03:59:59\Z')
         ];
         return 'http://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param);
+    }
+
+    private function getCreditType(string $type): string
+    {
+        switch ($type) {
+            case 'Acteur':
+                $type = 'actor';
+                break;
+            case 'Réalisateur':
+                $type = 'director';
+                break;
+            case 'Scénariste':
+                $type = 'writer';
+                break;
+            case 'Producteur':
+                $type = 'producer';
+                break;
+            case 'Musique':
+                $type = 'composer';
+                break;
+            case 'Créateur':
+                $type = 'editor';
+                break;
+            case 'Présentateur vedette':
+            case 'Autre présentateur':
+                $type = 'presenter';
+                break;
+            case 'Commentateur':
+                $type = 'commentator';
+                break;
+            case 'Origine Scénario':
+            case 'Scénario':
+                $type = 'adapter';
+                break;
+        }
+        return $type;
     }
 }

--- a/src/Component/Provider/NouvelObs.php
+++ b/src/Component/Provider/NouvelObs.php
@@ -49,17 +49,20 @@ class NouvelObs extends AbstractProvider implements ProviderInterface
             $start = $date . " " . str_replace("h", ":", $start[1]);
             $program = new Program(strtotime($start), strtotime($start) + intval($duration) * 60);
 
-            $program->addCategory(end(@explode('>', $category[1] ?? 'Inconnu')));
-            $desc = end(@explode('>', $desc[1][1])) ?? 'Aucune description';
+            $exp = explode('>', $category[1] ?? 'Inconnu');
+            $program->addCategory(end($exp));
+            $exp = explode('>', $desc[1][1]);
+            $desc = end($exp);
+            if(empty($desc)) { $desc = "Aucune description"; }
             $program->addDesc($desc);
             $program->addTitle($titre[1] ?? 'Aucun titre');
-            if (!is_null($season[1])) {
+            if (isset($season[1])) {
                 $program->setEpisodeNum($season[1], explode('/', $season[2])[0]);
             }
-            if (!is_null($image[1])) {
+            if (isset($image[1])) {
                 $program->setIcon(str_replace('/p/p/', '/p/g/', $image[1]));
             }
-            switch ($csa[1]) {
+            switch ($csa[1] ?? "") {
                 case '2':
                     $csa = '-10';
 

--- a/src/Component/Provider/Orange.php
+++ b/src/Component/Provider/Orange.php
@@ -65,7 +65,7 @@ class Orange extends AbstractProvider implements ProviderInterface
                 if ($val['season']['number'] =='') {
                     $val['season']['number'] ='1';
                 }
-                if ($val['episodeNumber'] =='') {
+                if (empty($val['episodeNumber'])) {
                     $val['episodeNumber'] ='1';
                 }
                 $program->addTitle($val['season']['serie']['title']);

--- a/src/Component/Provider/PlayTV.php
+++ b/src/Component/Provider/PlayTV.php
@@ -38,21 +38,21 @@ class PlayTV extends AbstractProvider implements ProviderInterface
         foreach ($json["data"] as $val) {
             $program = new Program(strtotime($val["start_at"]), strtotime($val["end_at"]));
 
-            $attrs = $val['media']['attrs'];
+            $attrs = $val['media']['attrs'] ?? [];
             $category = $val["media"]['path'][0]['category'] ?? 'Inconnu';
             $category[0] = strtoupper($category[0]);
             $program->addCategory($category);
             $program->addDesc($attrs["texts"]["long"] ?? $attrs["texts"]["short"] ?? 'Aucune description');
             $program->addTitle($val['title']);
-            if(!is_null($val["subtitle"])) {
+            if(isset($val["subtitle"])) {
                 $program->addSubtitle($val['subtitle']);
             }
-            if(!is_null($attrs["episode"])) {
+            if(isset($attrs["episode"])) {
                 $program->setEpisodeNum($attrs["season"] ?? '1', $attrs["episode"]);
             }
-            $images = $attrs["images"];
-            $image = $images['large'][0]["url"] ?? $images['thumbnail'][0]["url"];
-            if(!is_null($image)) {
+            $images = $attrs["images"] ?? [];
+            $image = $images['large'][0]["url"] ?? $images['thumbnail'][0]["url"] ?? null;
+            if(isset($image)) {
                 $program->setIcon($image);
             }
 

--- a/src/Component/Provider/Proximus.php
+++ b/src/Component/Provider/Proximus.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
 
-use _PHPStan_3bfe2e67c\Nette\Neon\Exception;
+use \Exception;
 use GuzzleHttp\Client;
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;

--- a/src/Component/Provider/SixPlay.php
+++ b/src/Component/Provider/SixPlay.php
@@ -38,7 +38,11 @@ class SixPlay extends AbstractProvider implements ProviderInterface
             foreach ($json[$channelId] as $program) {
                 $genre = "Inconnu";
 
-                $csa = ($program["csa"]["age"] > 0) ? strval(-$program["csa"]["age"]) : "Tout public";
+                if(isset($program["csa"]) && $program["csa"]["age"] > 0) {
+                    $csa = strval(-$program["csa"]["age"]);
+                } else {
+                    $csa = "Tout public";
+                }
 
                 $image = null;
                 foreach($program["images"] as $im) {

--- a/src/Component/Provider/Skweek.php
+++ b/src/Component/Provider/Skweek.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
 
-use _PHPStan_3bfe2e67c\Nette\Neon\Exception;
+use \Exception;
 use GuzzleHttp\Client;
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;
@@ -31,11 +31,12 @@ class Skweek extends AbstractProvider implements ProviderInterface
     private function setAPIKey() {
         $get = $this->getContentFromURL("https://app.skweek.tv/schedule");
         preg_match('/src="(.*?)app\.js"/', $get, $app);
-        $app[1] = end(@explode('src="', $app[1]));
+        $exp = explode('src="', $app[1]);
+        $app[1] = end($exp);
         $get = $this->getContentFromURL("https://app.skweek.tv$app[1]app.js");
         preg_match('/API_KEY:"(.*?)"/', $get, $key);
         preg_match('/OUTPUT_FOLDER:"(.*?)"/', $get, $version);
-        if(is_null($key[1])) {
+        if(!isset($key[1])) {
             throw new Exception("Error while getting API key");
         }
         self::$API_KEY = $key[1];
@@ -49,8 +50,8 @@ class Skweek extends AbstractProvider implements ProviderInterface
 
     }
     private function getAuthToken() {
-        if(is_null(self::$AUTH_TOKEN) || $this->isAuthTokenExpired()) {
-            if(is_null(self::$API_KEY)) {
+        if(!isset(self::$AUTH_TOKEN) || $this->isAuthTokenExpired()) {
+            if(!isset(self::$API_KEY)) {
                 $this->setAPIKey();
             }
             $response = $this->client->post("https://dce-frontoffice.imggaming.com/api/v2/login/guest/checkin",
@@ -77,7 +78,7 @@ class Skweek extends AbstractProvider implements ProviderInterface
                 ]]);
             $data = json_decode($response->getBody()->getContents(), true);
             self::$AUTH_TOKEN = $data["authorisationToken"];
-            if(is_null(self::$AUTH_TOKEN)) {
+            if(!isset(self::$AUTH_TOKEN)) {
                 throw new Exception("Error while getting authorisation token");
             }
         }
@@ -87,7 +88,7 @@ class Skweek extends AbstractProvider implements ProviderInterface
     public function constructEPG(string $channel, string $date)
     {
         $channelObj = parent::constructEPG($channel, $date);
-        if(!is_null(self::$currentAllowedDate) && (self::$nextAllowedDate != $date && self::$currentAllowedDate != $date)) { # Multiple days are available in one request
+        if(isset(self::$currentAllowedDate) && (self::$nextAllowedDate != $date && self::$currentAllowedDate != $date)) { # Multiple days are available in one request
             return false;
         }
         if (!$this->channelExists($channel)) {

--- a/src/Component/Provider/TVHebdo.php
+++ b/src/Component/Provider/TVHebdo.php
@@ -40,7 +40,7 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
             ['Referer'=>$this->proxy]
         );
         $res1 = html_entity_decode($res1, ENT_QUOTES);
-        @$res1 = explode('Mes<br>alertes courriel', $res1 ?? '')[1];
+        @$res1 = explode('Mes<br>alertes courriel', $res1)[1];
         if (empty($res1)) {
             return false;
         }
@@ -74,7 +74,7 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
             $url = $titre[1][$j];
             $content = (string)$response[$url]->getBody();
             $infos = str_replace("\n", ' ', explode('</h4>', explode('<h4>', $content)[1] ?? '')[0]);
-            $infos = explode(' - ', $infos ?? '');
+            $infos = explode(' - ', $infos);
             $genre = @trim($infos[0] ?? '');
             $duration = @intval(explode(' ', @trim($infos[1] ?? ''))[0]);
             $lang = @trim(strtolower($infos[2] ?? ''));
@@ -90,16 +90,16 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
                     $year = $potentialYear;
                 }
             }
-            $desc =@explode('</p>', explode('<p id="dd_desc">', $content ?? '')[1] ?? '')[0];
+            $desc =@explode('</p>', explode('<p id="dd_desc">', $content)[1] ?? '')[0];
             if (isset($year)) {
                 $desc.= "\n\nAnnée : ".$year;
             }
-            $intervenants = @explode('</p>', explode('<p id="dd_inter">', $content ?? '')[1] ?? '')[0];
+            $intervenants = @explode('</p>', explode('<p id="dd_inter">', $content)[1] ?? '')[0];
             $program = new Program($dateStart, $dateStart+$duration*60);
             $program->addTitle($titreProgram, $lang);
             $desc = str_replace('<br />', "\n", $desc.$intervenants);
             $tmp_desc = '';
-            $splited_desc = explode("\n", $desc ?? '');
+            $splited_desc = explode("\n", $desc);
             foreach ($splited_desc as $line) {
                 $tmp_desc.=@trim($line)."\n";
             }
@@ -107,7 +107,7 @@ class TVHebdo extends AbstractProvider implements ProviderInterface
             $program->addDesc($desc, $lang);
             $program->addCategory($genre, $lang);
             $current_role = 'guest';
-            $intervenants_split = explode('<br />', $intervenants ?? '');
+            $intervenants_split = explode('<br />', $intervenants);
             foreach ($intervenants_split as $line) {
                 $line = @trim($line);
                 if ($line == 'Réalisation :') {

--- a/src/Component/Provider/Tebeosud.php
+++ b/src/Component/Provider/Tebeosud.php
@@ -32,7 +32,7 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
         if (!$this->channelExists($channel)) {
             return false;
         }
-        $res1 = $this->getContentFromURL($this->generateUrl($channelObj, new \DateTimeImmutable($date))) ?? "";
+        $res1 = $this->getContentFromURL($this->generateUrl($channelObj, new \DateTimeImmutable($date)));
         $res1 = str_replace('"', "'", $res1);
         preg_match_all("/<p class='hour-program'>(.*?)<\/p>/s", $res1, $hours);
         preg_match_all("/<span class='video-card-date'>(.*?)<\/span>/s", $res1, $titles);
@@ -45,8 +45,11 @@ class Tebeosud extends AbstractProvider implements ProviderInterface
             $start = strtotime($date." ".$hours[1][$i]);
             if($i == count($titles) - 1) {
                 $end = $start + intval(explode(":", end($durations[1]))[0]) * 60;
-            } else {
+            } else if(isset($hours[1][$i + 1])) {
                 $end = strtotime($date." ".$hours[1][$i + 1]);
+            }
+            if(!isset($end)) {
+                continue;
             }
             $program = new Program($start, $end);
             $program->addTitle(trim($titles[1][$i]));

--- a/src/Component/Provider/TeleLoisirs.php
+++ b/src/Component/Provider/TeleLoisirs.php
@@ -33,7 +33,11 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
             Logger::updateLine(' '.round($index*100/$count, 2).' %');
             preg_match('/href="(.*?)" title="(.*?)"/', $li, $titlehref);
             preg_match('/srcset="(.*?)"/', $li, $img);
-            $img = str_replace('64x90', '640x360', explode(' ', @$img[1] ?? '')[0]);
+            if(!isset($img[1])) {
+                $img = "";
+            } else {
+                $img = str_replace('64x90', '640x360', explode(' ', $img[1])[0]);
+            }
             $genre = trim(explode('</div>', explode('<div class="mainBroadcastCard-genre">', $li)[1] ?? '')[0]);
             $genreFormat = trim(explode('</p>', explode('<p class="mainBroadcastCard-format">', $li)[1] ?? '')[0]);
             $subtitle = @trim(explode('</p>', explode('<p class="mainBroadcastCard-subtitle">', $li)[1] ?? '')[0]);

--- a/src/Component/Provider/Teleboy.php
+++ b/src/Component/Provider/Teleboy.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace racacax\XmlTv\Component\Provider;
 
-use _PHPStan_3bfe2e67c\Nette\Neon\Exception;
+use \Exception;
 use GuzzleHttp\Client;
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\ResourcePath;

--- a/src/Component/Provider/Telecablesat.php
+++ b/src/Component/Provider/Telecablesat.php
@@ -124,8 +124,8 @@ class Telecablesat extends AbstractProvider implements ProviderInterface
                         $program->setIcon('https:'.$imgs[1]);
                     }
                     $desc = '';
-                    if (isset($resume[1])) {
-                        $desc.=trim($resume[1] ?? '')."\n\n";
+                    if (!empty($resume[1])) {
+                        $desc.=trim($resume[1])."\n\n";
                     }
                     if (isset($critique[1])) {
                         $desc.='Critique : '.trim($critique[1])."\n\n";

--- a/src/Component/XmlFormatter.php
+++ b/src/Component/XmlFormatter.php
@@ -64,7 +64,7 @@ class XmlFormatter
 
     private function buildCredits(?array $credits): string
     {
-        if (empty($this->credits)) {
+        if (empty($credits)) {
             return '';
         }
 

--- a/src/ValueObject/Program.php
+++ b/src/ValueObject/Program.php
@@ -271,14 +271,16 @@ class Program
      */
     public function setEpisodeNum($season, $episode): void
     {
-        if(!isset($season) && isset($episode)) {
-            $season = 0;
-        }
-        if(!isset($episode) && isset($season)) {
-            $episode = 0;
-        }
         if (!isset($season) && !isset($episode)) {
             return;
+        }
+        $season = @(intval($season) - 1);
+        $episode = @(intval($episode) - 1);
+        if ($season < 0) {
+            $season = 0;
+        }
+        if ($episode < 0) {
+            $episode = 0;
         }
         $this->episode_num = $season . '.' . $episode;
     }

--- a/src/ValueObject/Program.php
+++ b/src/ValueObject/Program.php
@@ -74,12 +74,52 @@ class Program
      * @param mixed $name
      * @param mixed $type
      */
-    public function addCredit($name, $type): void
+    public function addCredit($name, $type = "guest"): void
     {
         if (!empty($name)) {
-            if (empty($type)) {
+            switch ($type) {
+            case 'actor':
+            case 'Acteur':
+                $type = 'actor';
+                break;
+            case 'director':
+            case 'Réalisateur':
+                $type = 'director';
+                break;
+            case 'writer':
+            case 'Scénariste':
+                $type = 'writer';
+                break;
+            case 'producer':
+            case 'Producteur':
+                $type = 'producer';
+                break;
+            case 'composer':
+            case 'Musique':
+                $type = 'composer';
+                break;
+            case 'editor':
+            case 'Créateur':
+                $type = 'editor';
+                break;
+            case 'presenter':
+            case 'Présentateur vedette':
+            case 'Autre présentateur':
+                $type = 'presenter';
+                break;
+            case 'commentator':
+            case 'Commentateur':
+                $type = 'commentator';
+                break;
+            case 'adapter':
+            case 'Origine Scénario':
+            case 'Scénario':
+                $type = 'adapter';
+                break;
+            default:
                 $type = 'guest';
-            }
+                break;
+            }           
             $this->credits[] = ['name' => $name, 'type' => $type];
         }
     }
@@ -231,16 +271,14 @@ class Program
      */
     public function setEpisodeNum($season, $episode): void
     {
-        if (!isset($season) && !isset($episode)) {
-            return;
-        }
-        $season = @(intval($season) - 1);
-        $episode = @(intval($episode) - 1);
-        if ($season < 0) {
+        if(!isset($season) && isset($episode)) {
             $season = 0;
         }
-        if ($episode < 0) {
+        if(!isset($episode) && isset($season)) {
             $episode = 0;
+        }
+        if (!isset($season) && !isset($episode)) {
+            return;
         }
         $this->episode_num = $season . '.' . $episode;
     }

--- a/src/ValueObject/Program.php
+++ b/src/ValueObject/Program.php
@@ -77,49 +77,10 @@ class Program
     public function addCredit($name, $type = "guest"): void
     {
         if (!empty($name)) {
-            switch ($type) {
-            case 'actor':
-            case 'Acteur':
-                $type = 'actor';
-                break;
-            case 'director':
-            case 'Réalisateur':
-                $type = 'director';
-                break;
-            case 'writer':
-            case 'Scénariste':
-                $type = 'writer';
-                break;
-            case 'producer':
-            case 'Producteur':
-                $type = 'producer';
-                break;
-            case 'composer':
-            case 'Musique':
-                $type = 'composer';
-                break;
-            case 'editor':
-            case 'Créateur':
-                $type = 'editor';
-                break;
-            case 'presenter':
-            case 'Présentateur vedette':
-            case 'Autre présentateur':
-                $type = 'presenter';
-                break;
-            case 'commentator':
-            case 'Commentateur':
-                $type = 'commentator';
-                break;
-            case 'adapter':
-            case 'Origine Scénario':
-            case 'Scénario':
-                $type = 'adapter';
-                break;
-            default:
-                $type = 'guest';
-                break;
-            }           
+            if(!in_array($type, ["actor", "director", "writer", "producer",
+                "composer", "editor", "presenter", "commentator", "adapter"])) {
+                $type = "guest";
+            }
             $this->credits[] = ['name' => $name, 'type' => $type];
         }
     }

--- a/src/ValueObject/Program.php
+++ b/src/ValueObject/Program.php
@@ -89,6 +89,25 @@ class Program
      */
     public function getCredits()
     {
+        usort($this->credits, function($a, $b) {
+            $priority = [
+                'director' => 1,
+                'actor' => 2,
+                'writer' => 3,
+                'adapter' => 4,
+                'producer' => 5,
+                'composer' => 6,
+                'editor' => 7,
+                'presenter' => 8,
+                'commentator' => 9,
+                'guest' => 10
+            ];
+    
+            $priorityA = isset($priority[$a['type']]) ? $priority[$a['type']] : PHP_INT_MAX;
+            $priorityB = isset($priority[$b['type']]) ? $priority[$b['type']] : PHP_INT_MAX;
+    
+            return $priorityA - $priorityB;
+        });
         return $this->credits;
     }
 

--- a/tests/Integration/ProvidersTest.php
+++ b/tests/Integration/ProvidersTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use racacax\XmlTv\Component\Provider\AmazonPrime;
 use racacax\XmlTv\Component\Provider\PlutoTV;
 use racacax\XmlTv\Component\Provider\Skweek;
+use racacax\XmlTv\Component\Provider\Teleboy;
 use racacax\XmlTv\Component\Provider\TVHebdo;
 use racacax\XmlTv\Component\Provider\ViniPF;
 use racacax\XmlTv\Component\ProviderInterface;
@@ -75,7 +76,9 @@ class ProvidersTest extends TestCase
 
         foreach ($providers as $provider) {
             // ignore geoblocked and minor providers
-            if (in_array(get_class($provider), [PlutoTV::class, TVHebdo::class, AmazonPrime::class, Skweek::class])
+            if (in_array(get_class($provider), [
+                PlutoTV::class, TVHebdo::class, AmazonPrime::class, Skweek::class, Teleboy::class
+            ])
             ) {
                 continue;
             }

--- a/tests/Integration/ProvidersTest.php
+++ b/tests/Integration/ProvidersTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace racacax\XmlTvTest\Integration;
 
 use PHPUnit\Framework\TestCase;
+use racacax\XmlTv\Component\Provider\AmazonPrime;
 use racacax\XmlTv\Component\Provider\PlutoTV;
+use racacax\XmlTv\Component\Provider\Skweek;
+use racacax\XmlTv\Component\Provider\TVHebdo;
 use racacax\XmlTv\Component\Provider\ViniPF;
 use racacax\XmlTv\Component\ProviderInterface;
 use racacax\XmlTv\Component\Utils;
@@ -71,8 +74,9 @@ class ProvidersTest extends TestCase
         $providers = $configurator->getGenerator()->getProviders();
 
         foreach ($providers as $provider) {
-            // ignore PlutoTv
-            if (PlutoTV::class === get_class($provider)) {
+            // ignore geoblocked and minor providers
+            if (in_array(get_class($provider), [PlutoTV::class, TVHebdo::class, AmazonPrime::class, Skweek::class])
+            ) {
                 continue;
             }
             yield [$provider];


### PR DESCRIPTION
Lorsque des intervenants étaient ajoutés, rien n'apparaissait lors de l'export ; désormais, cela est bien pris en compte.