### PR TITLE
Fix : HTTP => HTTPS pour Bouygues

### DIFF
--- a/src/Component/Provider/Bouygues.php
+++ b/src/Component/Provider/Bouygues.php
@@ -101,7 +101,7 @@ class Bouygues extends AbstractProvider implements ProviderInterface
             'startTime'=>$date->format('Y-m-d\T04:00:00\Z'),
             'endTime'=>$date->modify('+1 days')->format('Y-m-d\T03:59:59\Z')
         ];
-        return 'http://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param);
+        return 'https://epg.cms.pfs.bouyguesbox.fr/cms/sne/live/epg/events.json?' . http_build_query($param);
     }
 
     private function getCreditType(string $type): string


### PR DESCRIPTION
L'URL de bouygues ne répond plus sur le port 80 (HTTP) 
`
root@srv01:~# wget http://epg.cms.pfs.bouyguesbox.fr
--2024-06-10 08:27:08--  http://epg.cms.pfs.bouyguesbox.fr/
Résolution de epg.cms.pfs.bouyguesbox.fr (epg.cms.pfs.bouyguesbox.fr)… 2001:860:de00:4000::210, 195.36.152.210
Connexion à epg.cms.pfs.bouyguesbox.fr (epg.cms.pfs.bouyguesbox.fr)|2001:860:de00:4000::210|:80… échec : Connexion refusée.
Connexion à epg.cms.pfs.bouyguesbox.fr (epg.cms.pfs.bouyguesbox.fr)|195.36.152.210|:80… échec : Connexion refusée.
`
`
root@srv01:~# wget https://epg.cms.pfs.bouyguesbox.fr
--2024-06-10 08:27:15--  https://epg.cms.pfs.bouyguesbox.fr/
Résolution de epg.cms.pfs.bouyguesbox.fr (epg.cms.pfs.bouyguesbox.fr)… 2001:860:de00:4000::210, 195.36.152.210
Connexion à epg.cms.pfs.bouyguesbox.fr (epg.cms.pfs.bouyguesbox.fr)|2001:860:de00:4000::210|:443… connecté.
requête HTTP transmise, en attente de la réponse… 404 Not Found
2024-06-10 08:27:17 erreur 404 : Not Found
`

Je ferai les tests sur les autres URLs quand j'aurai le temps