### PR TITLE
Show 'guest' only when details enabled

### DIFF
--- a/src/Component/Provider/SudInfo.php
+++ b/src/Component/Provider/SudInfo.php
@@ -130,7 +130,10 @@ class SudInfo extends AbstractProvider implements ProviderInterface
             if (isset($cast['role'])) {
                 $str .= ' ('.$cast['role'].')';
             }
-            $programObj->addCredit($str, $this->getCreditFromCastFunction(@($cast['castFunction'] ?? [])['name'] ?? ''));
+            $castFunction = @($cast['castFunction'] ?? [];
+            if ($this->enableDetails || $castFunction != 'guest') {
+                $programObj->addCredit($str, $this->getCreditFromCastFunction($castFunction)['name'] ?? ''));
+            }
         }
 
     }

--- a/src/Component/Provider/TeleLoisirs.php
+++ b/src/Component/Provider/TeleLoisirs.php
@@ -94,7 +94,7 @@ class TeleLoisirs extends AbstractProvider implements ProviderInterface
                 } else {
                     $tag = 'guest';
                 }
-                if (!isset($detailJson)) {
+                if (!isset($detailJson) && ($this->enableDetails || $tag != 'guest')) {
                     $program->addCredit($name, $tag);
                 }
                 $synopsis .= $name . " ($role), ";

--- a/src/Component/Provider/Telerama.php
+++ b/src/Component/Provider/Telerama.php
@@ -119,7 +119,9 @@ class Telerama extends AbstractProvider implements ProviderInterface
                             $libelle = 'director';
                         }
                     }
-                    $program->addCredit($intervenant['prenom'] . ' ' . $intervenant['nom'] . $role, $libelle);
+                    if ($this->enableDetails || $libelle != 'guest') {
+                        $program->addCredit($intervenant['prenom'] . ' ' . $intervenant['nom'] . $role, $libelle);
+                    }
                 }
                 $keys = array_keys($intervenants);
                 for ($i = 0; $i < count($intervenants); $i++) {


### PR DESCRIPTION
Hello,
J'ai remarqué que le champ 'guest' était un peu la poubelle concernant les catégories de personne, beaucoup d'info inutile, exemples:
      ```
<guest> Volapuk</guest>
      <guest>Les Films du Kiosque</guest>
      <guest>France Télévisions</guest>
      <guest>Arnaud Bouniort</guest>
      <guest>SofiTVciné 10</guest>
      <guest>France 3 Cinéma</guest>
      <guest>Cinémage 17</guest>
      <guest>Indéfilms 11</guest>
      <guest> Ciné+</guest>
      <guest> Umedia</guest>
      <guest>Cinéaxe 4</guest>
      <guest>Cofimage 34</guest>
      <guest> Canal+</guest>```

L'idée est de mettre ces infos sous l'option: $this->enableDetails
Ca fera gagner pas mal de place
