### PR TITLE
update rating pictures

### DIFF
--- a/resources/information/ratings_picto.json
+++ b/resources/information/ratings_picto.json
@@ -1,30 +1,30 @@
 {
   "csa": {
-    "-10": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Moins10.svg/200px-Moins10.svg.png",
-    "-12": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Moins12.svg/200px-Moins12.svg.png",
-    "-16": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Moins16.svg/200px-Moins16.svg.png",
-    "-18": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2d/Moins18.svg/200px-Moins18.svg.png"
+    "-10": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/bf/Moins10.svg/250px-Moins10.svg.png",
+    "-12": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b5/Moins12.svg/250px-Moins12.svg.png",
+    "-16": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/29/Moins16.svg/250px-Moins16.svg.png",
+    "-18": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/2d/Moins18.svg/250px-Moins18.svg.png"
   },
   "fcc": {
-    "tv-y": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/TV-Y_icon.svg/200px-TV-Y_icon.svg.png",
-    "tv-y7": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/TV-Y7_icon.svg/800px-TV-Y7_icon.svg.png",
-    "tv-g": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/TV-G_icon.svg/800px-TV-G_icon.svg.png",
-    "tv-pg": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/TV-PG_icon.svg/800px-TV-PG_icon.svg.png",
-    "tv-14": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/TV-14_icon.svg/800px-TV-14_icon.svg.png",
-    "tv-ma": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/TV-MA_icon.svg/800px-TV-MA_icon.svg.png"
+    "tv-y": "https://upload.wikimedia.org/wikipedia/commons/thumb/2/25/TV-Y_icon.svg/250px-TV-Y_icon.svg.png",
+    "tv-y7": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5a/TV-Y7_icon.svg/250px-TV-Y7_icon.svg.png",
+    "tv-g": "https://upload.wikimedia.org/wikipedia/commons/thumb/5/5e/TV-G_icon.svg/250px-TV-G_icon.svg.png",
+    "tv-pg": "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9a/TV-PG_icon.svg/250px-TV-PG_icon.svg.png",
+    "tv-14": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c3/TV-14_icon.svg/250px-TV-14_icon.svg.png",
+    "tv-ma": "https://upload.wikimedia.org/wikipedia/commons/thumb/3/34/TV-MA_icon.svg/250px-TV-MA_icon.svg.png"
   },
   "rcq": {
-    "g": "https://en-academic.com/pictures/enwiki/54/60px-Quebecrating-G.png",
-    "13": "https://en-academic.com/pictures/enwiki/54/60px-Quebecrating-13.png",
-    "16": "https://en-academic.com/pictures/enwiki/54/60px-Quebecrating-16.png",
-    "18": "https://en-academic.com/pictures/enwiki/54/60px-Quebecrating-18.png"
+    "g": "https://upload.wikimedia.org/wikipedia/commons/thumb/6/6a/Quebec_Rating_G.svg/330px-Quebec_Rating_G.svg.png",
+    "13": "https://upload.wikimedia.org/wikipedia/commons/thumb/f/f6/Quebec_Rating_13.svg/330px-Quebec_Rating_13.svg.png",
+    "16": "https://upload.wikimedia.org/wikipedia/commons/thumb/d/df/Quebec_Rating_16.svg/330px-Quebec_Rating_16.svg.png",
+    "18": "https://upload.wikimedia.org/wikipedia/commons/thumb/b/b3/Quebec_Rating_18.svg/330px-Quebec_Rating_18.svg.png"
   },
   "chvrs": {
-    "g": "https://upload.wikimedia.org/wikipedia/en/thumb/e/ed/Canadian_Rating_G.png/200px-Canadian_Rating_G.png",
-    "pg": "https://upload.wikimedia.org/wikipedia/en/thumb/c/ce/Canadian_Rating_PG.png/200px-Canadian_Rating_PG.png",
-    "14a": "https://upload.wikimedia.org/wikipedia/en/thumb/2/20/Canadian_Rating_14A.png/200px-Canadian_Rating_14A.png",
-    "18a": "https://upload.wikimedia.org/wikipedia/en/thumb/c/cc/Canadian_Rating_18A.png/200px-Canadian_Rating_18A.png",
-    "r": "https://upload.wikimedia.org/wikipedia/en/thumb/6/66/Canadian_Rating_R.png/200px-Canadian_Rating_R.png",
-    "a": "https://upload.wikimedia.org/wikipedia/en/thumb/7/78/Canadian_Rating_A.png/200px-Canadian_Rating_A.png"
+    "g": "https://upload.wikimedia.org/wikipedia/commons/thumb/1/14/Canadian_Film_Rating_G.svg/250px-Canadian_Film_Rating_G.svg.png",
+    "pg": "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e9/Canadian_Film_Rating_PG.svg/330px-Canadian_Film_Rating_PG.svg.png",
+    "14a": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/72/Canadian_Film_Rating_14A.svg/250px-Canadian_Film_Rating_14A.svg.png",
+    "18a": "https://upload.wikimedia.org/wikipedia/commons/thumb/8/86/Canadian_Film_Rating_18A.svg/250px-Canadian_Film_Rating_18A.svg.png",
+    "r": "https://upload.wikimedia.org/wikipedia/commons/thumb/a/a6/Canadian_Film_Rating_R.svg/250px-Canadian_Film_Rating_R.svg.png",
+    "a": "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c5/Canadian_Film_Rating_A.svg/250px-Canadian_Film_Rating_A.svg.png"
   }
 }


### PR DESCRIPTION
Hi,

Most rating logos were dead links, I replaced them with the closest thumbnail size available.

For FCC I downsized the unavailable 800px to 250 so that it's uniform with the rest

For Quebec ratings I updated to the new logos using the wikimedia thumbnails too